### PR TITLE
feat(docs): add Starlight documentation site with Cloudflare Pages

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.astro/

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,0 +1,78 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  site: 'https://graphdb.pages.dev',
+  integrations: [
+    starlight({
+      title: 'GraphDB',
+      description:
+        'An in-memory database with sync capabilities. Zero runtime deps. TypeScript-first.',
+      social: {
+        github: 'https://github.com/alexvcasillas/graphdb',
+      },
+      editLink: {
+        baseUrl: 'https://github.com/alexvcasillas/graphdb/edit/master/apps/docs/',
+      },
+      head: [
+        {
+          tag: 'meta',
+          attrs: {
+            name: 'og:image',
+            content: 'https://graphdb.pages.dev/og.png',
+          },
+        },
+      ],
+      sidebar: [
+        {
+          label: 'Getting Started',
+          items: [
+            { label: 'Installation', slug: 'getting-started/installation' },
+            { label: 'Quick Start', slug: 'getting-started/quick-start' },
+            { label: 'Migration to v2', slug: 'getting-started/migration-v2' },
+          ],
+        },
+        {
+          label: 'Guides',
+          items: [
+            { label: 'CRUD Operations', slug: 'guides/crud-operations' },
+            { label: 'Querying', slug: 'guides/querying' },
+            { label: 'Indexes', slug: 'guides/indexes' },
+            { label: 'Sorting & Pagination', slug: 'guides/sorting-pagination' },
+            { label: 'Listeners & Events', slug: 'guides/listeners-events' },
+            { label: 'Syncers', slug: 'guides/syncers' },
+            { label: 'Bulk Operations', slug: 'guides/bulk-operations' },
+            { label: 'TypeScript Types', slug: 'guides/typescript-types' },
+          ],
+        },
+        {
+          label: 'API Reference',
+          items: [
+            { label: 'GraphDB', slug: 'api-reference/graphdb' },
+            { label: 'Collection', slug: 'api-reference/collection' },
+            { label: 'Where Clauses', slug: 'api-reference/where-clauses' },
+            { label: 'Types', slug: 'api-reference/types' },
+          ],
+        },
+        {
+          label: 'Advanced',
+          items: [
+            { label: 'Architecture', slug: 'advanced/architecture' },
+            { label: 'Performance', slug: 'advanced/performance' },
+            { label: 'Error Handling', slug: 'advanced/error-handling' },
+            { label: 'Patterns', slug: 'advanced/patterns' },
+          ],
+        },
+        {
+          label: 'Examples',
+          items: [
+            { label: 'Basic Usage', slug: 'examples/basic-usage' },
+            { label: 'Real-Time UI', slug: 'examples/real-time-ui' },
+            { label: 'Backend Sync', slug: 'examples/backend-sync' },
+            { label: 'Testing', slug: 'examples/testing' },
+          ],
+        },
+      ],
+    }),
+  ],
+});

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,13 +2,23 @@
   "name": "@graphdb/docs",
   "version": "0.0.0",
   "private": true,
-  "description": "GraphDB documentation website (placeholder)",
+  "description": "GraphDB documentation website",
   "license": "MIT",
   "scripts": {
-    "lint": "echo 'no lint configured yet'",
-    "typecheck": "echo 'no typecheck configured yet'",
-    "build": "echo 'no build configured yet'",
-    "clean": "echo 'no clean configured yet'",
-    "test": "echo 'no tests configured yet'"
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "clean": "rm -rf dist .astro",
+    "typecheck": "astro check",
+    "lint": "astro check",
+    "test": "echo 'no tests configured'"
+  },
+  "dependencies": {
+    "@astrojs/starlight": "^0.32.0",
+    "astro": "^5.3.0",
+    "sharp": "^0.33.0"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.0"
   }
 }

--- a/apps/docs/public/favicon.svg
+++ b/apps/docs/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="24" fill="#1a1a2e"/>
+  <circle cx="64" cy="48" r="16" stroke="#e94560" stroke-width="6" fill="none"/>
+  <circle cx="40" cy="88" r="16" stroke="#0f3460" stroke-width="6" fill="none"/>
+  <circle cx="88" cy="88" r="16" stroke="#16213e" stroke-width="6" fill="none"/>
+  <line x1="56" y1="62" x2="46" y2="74" stroke="#e94560" stroke-width="4" stroke-linecap="round"/>
+  <line x1="72" y1="62" x2="82" y2="74" stroke="#e94560" stroke-width="4" stroke-linecap="round"/>
+  <line x1="54" y1="88" x2="74" y2="88" stroke="#e94560" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,0 +1,54 @@
+# GraphDB
+
+> An in-memory database with sync capabilities. Zero runtime deps. TypeScript-first.
+
+GraphDB is a lightweight, TypeScript-first in-memory database that provides:
+- Collection-based document storage with auto-generated IDs and timestamps
+- Powerful query engine with where clauses, operators, sorting, and pagination
+- Optional hash indexes for O(1) equality lookups
+- Real-time listeners for collection events and per-document changes
+- Backend synchronization with optimistic writes and automatic revert on failure
+- Zero runtime dependencies
+
+## Install
+
+```bash
+bun add @graphdb/core
+```
+
+## Quick Example
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+const db = GraphDB();
+db.createCollection<{ name: string; age: number }>('users', {
+  indexes: ['name'],
+});
+
+const users = db.getCollection<{ name: string; age: number }>('users')!;
+const id = await users.create({ name: 'Alex', age: 29 });
+const doc = users.read(id);
+
+// Query with operators
+const results = users.query({ age: { gt: 25 } });
+
+// Listen to changes
+const cancel = users.on('create', ({ doc }) => console.log('New:', doc));
+cancel(); // unsubscribe
+```
+
+## Key Concepts
+
+- **Doc<T>**: Every document gets `_id` (UUID), `createdAt`, and `updatedAt` (epoch ms)
+- **Where clauses**: Primitive equality, RegExp, or operator objects (eq, notEq, gt, gte, lt, lte, includes, startsWith, endsWith, match, in)
+- **Sync reads, async writes**: read/query/findOne are synchronous; create/update/remove are async (for syncer support)
+- **Syncers**: Optimistic writes that revert on sync failure
+- **Events**: create, update, remove, populate, syncError — all with typed payloads
+
+## Links
+
+- Documentation: https://graphdb.pages.dev
+- Full LLM context: https://graphdb.pages.dev/llms-full.txt
+- GitHub: https://github.com/alexvcasillas/graphdb
+- npm: https://www.npmjs.com/package/@graphdb/core

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://graphdb.pages.dev/sitemap-index.xml

--- a/apps/docs/src/content.config.ts
+++ b/apps/docs/src/content.config.ts
@@ -1,0 +1,6 @@
+import { docsSchema } from '@astrojs/starlight/schema';
+import { defineCollection } from 'astro:content';
+
+export const collections = {
+  docs: defineCollection({ schema: docsSchema() }),
+};

--- a/apps/docs/src/content/docs/advanced/architecture.md
+++ b/apps/docs/src/content/docs/advanced/architecture.md
@@ -1,0 +1,225 @@
+---
+title: Architecture
+description: Internal architecture and design decisions of GraphDB.
+---
+
+This page explains how GraphDB is built internally. Understanding the architecture helps you make informed decisions about data modeling, indexing, and when to reach for specific APIs.
+
+## High-level overview
+
+```
++---------------------------------------------------+
+|                    GraphDB()                       |
+|              (factory function)                    |
+|                                                    |
+|   Returns GraphDBType: thin wrapper holding        |
+|   Map<string, Collection>                          |
+|                                                    |
+|   +---------------------------------------------+ |
+|   | createCollection<T>(options?)                | |
+|   |                                              | |
+|   | +----------+  +---------+  +-------------+  | |
+|   | | Storage  |  | Indexes |  | Listeners   |  | |
+|   | | Map<     |  | Map<    |  | Map<Event,  |  | |
+|   | |  id,     |  |  field, |  |  Set<fn>>   |  | |
+|   | |  Doc<T>> |  |  Map<   |  |             |  | |
+|   | |          |  |   value,|  | Map<docId,  |  | |
+|   | |          |  |   Set<  |  |  Set<fn>>   |  | |
+|   | |          |  |   id>>> |  +-------------+  | |
+|   | +----------+  +---------+                    | |
+|   |                                              | |
+|   | +----------+  +-----------+                  | |
+|   | | Syncers  |  | Utilities |                  | |
+|   | | (optional|  | - where   |                  | |
+|   | |  async   |  |   checker |                  | |
+|   | |  hooks)  |  | - sort    |                  | |
+|   | +----------+  | - isEmpty |                  | |
+|   |               +-----------+                  | |
+|   +---------------------------------------------+ |
++---------------------------------------------------+
+```
+
+## Closure-based design
+
+GraphDB uses closure-based encapsulation rather than classes. The `createCollection()` function declares all internal state as local variables and returns a plain object whose methods close over that state. This means:
+
+- **Private by default.** Internal structures like the document `Map`, index `Map`, and listener `Set` instances are not accessible from outside. There is no `this` to leak, no prototype to monkey-patch, and no need for `#private` fields or `WeakMap` tricks.
+- **No `this` binding issues.** Every returned method is a plain closure. You can destructure, pass callbacks around, or assign methods to variables without worrying about lost context.
+- **Simpler testing.** The returned object is a plain JavaScript object with predictable behavior.
+
+```ts
+// Simplified mental model of createCollection
+function createCollection<T>(options?) {
+  // Private state -- not reachable from outside
+  const documents = new Map<string, Doc<T>>();
+  const indexes = new Map<keyof T, Map<unknown, Set<string>>>();
+  const onListeners = new Map<EventType, Set<(payload: any) => void>>();
+  const docListeners = new Map<string, Set<(payload: ListenerPayload<T>) => void>>();
+
+  // Public API -- closes over private state
+  return {
+    create(doc) { /* ... */ },
+    read(id) { /* ... */ },
+    update(id, patch) { /* ... */ },
+    remove(id) { /* ... */ },
+    query(where, options) { /* ... */ },
+    // ...
+  };
+}
+```
+
+## Document storage
+
+Documents are stored in a `Map<string, Doc<T>>`. The key is the document's `_id`, a string generated via `crypto.randomUUID()` at creation time. Each document is stored as a `Doc<T>`, which extends your type `T` with system fields:
+
+```ts
+type Doc<T> = T & {
+  _id: string;
+  _createdAt: number;  // epoch milliseconds
+  _updatedAt: number;  // epoch milliseconds
+};
+```
+
+Timestamps are epoch milliseconds (`number`), not `Date` objects. This makes comparisons trivial and avoids serialization issues.
+
+Using a `Map` provides:
+
+- O(1) `read(id)` via `Map.get()`
+- O(1) `exists(id)` via `Map.has()`
+- O(1) `count()` (no filter) via `Map.size`
+- Insertion-order iteration when scanning
+
+## Index structure
+
+Indexes follow a three-level `Map` structure:
+
+```
+indexes: Map<field, Map<value, Set<docId>>>
+```
+
+For example, given a collection of users indexed on `age`:
+
+```
+indexes = Map {
+  "age" => Map {
+    25 => Set { "uuid-1", "uuid-4" },
+    30 => Set { "uuid-2" },
+    35 => Set { "uuid-3", "uuid-5", "uuid-7" }
+  }
+}
+```
+
+When you create a collection with `indexes: ['age']`, GraphDB initializes an empty `Map` for the `age` field. As documents are created, updated, or removed, three internal helpers maintain index consistency:
+
+- **`indexAdd(doc)`** -- iterates each indexed field, gets the field's value from the document, and adds the document's `_id` to the corresponding `Set`. Creates the `Set` if it does not exist yet.
+- **`indexRemove(doc)`** -- reverse of `indexAdd`. Removes the `_id` from the `Set` and cleans up empty `Set` entries to avoid memory leaks.
+- **`indexUpdate(before, after)`** -- for each indexed field, compares old and new values. If unchanged, skips the field. Otherwise, removes from the old bucket and adds to the new one.
+
+## Query planner
+
+The query pipeline follows this order: **filter -> sort -> skip -> limit**.
+
+The filter phase uses a function called `getCandidateIds()` that determines whether any `where` clause fields have indexes. The algorithm works as follows:
+
+1. **Check for indexed fields.** For each field in the `where` clause, check if an index exists for that field.
+2. **Equality lookups.** If the where value is a primitive (string, number, boolean) or uses the `eq` operator, look up the exact value in the index to get a `Set<docId>`. This is O(1).
+3. **`in` operator lookups.** If the where value uses the `in` operator with an array, perform one lookup per array element and union the results. This is O(m) where m is the array length.
+4. **Set intersection (smallest-first).** When multiple indexed fields match, sort the candidate sets by size (smallest first) and intersect them. This minimizes the number of comparisons because the smallest set bounds the maximum result size.
+5. **Evaluate remaining clauses.** Non-indexed fields and operators that cannot use indexes (like `gt`, `lt`, `contains`, `regex`) are evaluated on the candidate documents only, not the full collection.
+
+If no indexed fields match the query, the planner falls through to a full scan of all documents.
+
+```
+Query: { age: 25, name: "Alice" }
+Indexes: ["age"]
+
+1. "age" is indexed -> look up value 25 -> Set { "uuid-1", "uuid-4" }
+2. "name" is NOT indexed -> skip index phase
+3. Candidate set: { "uuid-1", "uuid-4" } (2 docs, not full collection)
+4. Evaluate "name === Alice" only on those 2 candidates
+```
+
+## Listener system
+
+GraphDB provides two listener mechanisms, both built on `Map<key, Set<handler>>`:
+
+### Collection-level events (`on`)
+
+```
+onListeners: Map<EventType, Set<handler>>
+```
+
+Events include `created`, `updated`, `removed`, and `syncError`. When an event fires, GraphDB iterates the `Set` for that event type and calls each handler.
+
+### Per-document listeners (`listen`)
+
+```
+docListeners: Map<docId, Set<handler>>
+```
+
+`listen(id, callback)` attaches a handler that fires whenever the specified document is updated or removed. This enables fine-grained reactivity -- you can watch a single document without receiving events for the entire collection.
+
+### O(1) unsubscribe
+
+Both `on()` and `listen()` return a cancel function. Internally, this cancel function calls `Set.delete(handler)`, which is O(1). There is no array scanning or splicing involved:
+
+```ts
+const cancel = users.on('created', (payload) => {
+  console.log('New user:', payload.doc);
+});
+
+// Later: O(1) unsubscribe
+cancel();
+```
+
+## Syncer system
+
+Syncers enable optimistic writes. The pattern is:
+
+1. **Apply the write immediately** to the in-memory store (create, update, or remove).
+2. **Call the async syncer function** and await its result.
+3. **If the syncer returns `true`**, the write stands. Nothing more happens.
+4. **If the syncer returns `false` or throws**, GraphDB reverts the write automatically:
+   - For `create`: removes the newly created document.
+   - For `update`: restores the previous version of the document.
+   - For `remove`: re-inserts the removed document.
+5. **Emit a `syncError` event** so centralized error handlers can react.
+6. **Throw an error** so the caller's `catch` block can handle it.
+
+This design means the UI always sees an immediate response, and corrections happen asynchronously if the backend rejects the write.
+
+```
+Timeline:
+
+  create(doc) called
+       |
+       v
+  [Doc written to Map]  <-- UI sees new doc immediately
+       |
+       v
+  [syncer.create(doc) called]
+       |
+       +-- success --> done
+       |
+       +-- failure --> [Doc removed from Map]
+                       [syncError event emitted]
+                       [Error thrown]
+```
+
+## Utility functions
+
+### `whereChecker(doc, field, clause)`
+
+Evaluates a single `where` clause against one field of a document. Handles:
+
+- **Primitive values**: direct equality check (`doc[field] === clause`)
+- **RegExp values**: tests the field value against the regular expression
+- **Operator objects**: evaluates operators like `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, and `regex`
+
+### `sortDocuments(docs, sort)`
+
+Multi-field sort supporting `ASC` and `DESC` directions. Uses `String.prototype.localeCompare()` for string fields and numeric subtraction for numbers. Fields are evaluated in order -- the first field is the primary sort key, the second is the tiebreaker, and so on.
+
+### `isEmptyObject(obj)`
+
+A fast empty-object check using a `for...in` loop that returns `false` on the first property found. Faster than `Object.keys(obj).length === 0` because it avoids allocating an array.

--- a/apps/docs/src/content/docs/advanced/error-handling.md
+++ b/apps/docs/src/content/docs/advanced/error-handling.md
@@ -1,0 +1,327 @@
+---
+title: Error Handling
+description: Complete error catalog and handling patterns.
+---
+
+GraphDB throws specific error messages for invalid operations and sync failures. This page catalogs every error, explains when it occurs, and shows how to handle each one.
+
+## Error catalog
+
+### Validation errors
+
+These errors are thrown synchronously when you pass invalid arguments to a write operation.
+
+#### Missing ID on update
+
+```
+"You must provide the GraphDocument ID that you would like to update."
+```
+
+**When it occurs:** You call `update()` with an empty string or falsy value as the document ID.
+
+```ts
+type User = { name: string; email: string; age: number };
+
+// This throws immediately
+await users.update('', { name: 'Alice' });
+```
+
+**How to handle:** Ensure you always pass a valid `_id` string. This typically indicates a bug in your code where a variable holding the ID is uninitialized.
+
+#### Document not found on update
+
+```
+"No document to update found with ID: {id}"
+```
+
+**When it occurs:** You call `update()` with a valid string ID, but no document with that ID exists in the collection.
+
+```ts
+// This throws if the ID does not match any document
+await users.update('nonexistent-uuid', { name: 'Alice' });
+```
+
+**How to handle:** Check if the document exists before updating, or wrap the call in a try/catch:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+const doc = users.read(id);
+if (doc) {
+  await users.update(id, { name: 'Alice' });
+}
+```
+
+#### Missing ID on remove
+
+```
+"You must provide the GraphDocument ID that you would like to remove."
+```
+
+**When it occurs:** You call `remove()` with an empty string or falsy value.
+
+```ts
+// This throws immediately
+await users.remove('');
+```
+
+**How to handle:** Same as the update case -- ensure the ID variable is valid before calling `remove()`.
+
+#### Document not found on remove
+
+```
+"No document to remove found with ID: {id}"
+```
+
+**When it occurs:** You call `remove()` with a valid string ID, but no document with that ID exists.
+
+```ts
+// This throws if the document was already removed or never existed
+await users.remove('nonexistent-uuid');
+```
+
+**How to handle:** Check existence first or use try/catch:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+if (users.exists(id)) {
+  await users.remove(id);
+}
+```
+
+### Populate errors
+
+#### Missing `_id` in populated documents
+
+```
+"Every document must have an _id for populate."
+```
+
+**When it occurs:** You call `populate()` with an array of documents where at least one document is missing the `_id` field. Unlike `create()`, which generates an `_id` automatically, `populate()` expects pre-existing documents that already have IDs.
+
+```ts
+type User = { name: string; email: string; age: number };
+
+// This throws because the document has no _id
+users.populate([
+  { name: 'Alice', email: 'alice@example.com', age: 25 } as any,
+]);
+```
+
+**How to handle:** Ensure every document passed to `populate()` includes `_id`, `_createdAt`, and `_updatedAt`. These typically come from your backend API:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+const apiUsers = await fetchUsersFromAPI();
+
+users.populate(apiUsers.map((u) => ({
+  _id: u.id,
+  _createdAt: u.createdAt,
+  _updatedAt: u.updatedAt,
+  name: u.name,
+  email: u.email,
+  age: u.age,
+})));
+```
+
+### Sync errors
+
+Sync errors occur when a syncer function returns `false` or throws. GraphDB handles these by reverting the optimistic write, emitting a `syncError` event, and then throwing an error.
+
+#### Create sync failure
+
+```
+"Document synchronization wasn't possible."
+```
+
+**When it occurs:** The `create` syncer returns `false` or throws after a document was optimistically created.
+
+```ts
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+const users = db.collection<User>('users', {
+  syncers: {
+    create: async (doc) => {
+      const response = await fetch('/api/users', {
+        method: 'POST',
+        body: JSON.stringify(doc),
+      });
+      return response.ok; // returns false on failure
+    },
+  },
+});
+
+try {
+  await users.create({ name: 'Alice', email: 'alice@example.com', age: 25 });
+} catch (error) {
+  // error.message === "Document synchronization wasn't possible."
+  // The document has already been removed from the collection
+  console.error('Failed to sync new user:', error);
+}
+```
+
+#### Update sync failure
+
+```
+"[UPDATE SYNC]: Document synchronization wasn't possible."
+```
+
+**When it occurs:** The `update` syncer returns `false` or throws after a document was optimistically updated.
+
+```ts
+try {
+  await users.update(userId, { age: 26 });
+} catch (error) {
+  // error.message === "[UPDATE SYNC]: Document synchronization wasn't possible."
+  // The document has been reverted to its previous state
+  console.error('Failed to sync user update:', error);
+}
+```
+
+#### Remove sync failure
+
+```
+"[REMOVE SYNC]: Document synchronization wasn't possible."
+```
+
+**When it occurs:** The `remove` syncer returns `false` or throws after a document was optimistically removed.
+
+```ts
+try {
+  await users.remove(userId);
+} catch (error) {
+  // error.message === "[REMOVE SYNC]: Document synchronization wasn't possible."
+  // The document has been re-inserted into the collection
+  console.error('Failed to sync user removal:', error);
+}
+```
+
+## Handling patterns
+
+### Try/catch for individual operations
+
+The most straightforward approach. Wrap each write in a try/catch to handle errors at the call site:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+async function updateUserAge(id: string, newAge: number): Promise<boolean> {
+  try {
+    await users.update(id, { age: newAge });
+    return true;
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('No document to update found')) {
+        console.warn(`User ${id} no longer exists`);
+      } else if (error.message.includes('synchronization')) {
+        console.warn(`Sync failed for user ${id}, change reverted`);
+      }
+    }
+    return false;
+  }
+}
+```
+
+### Centralized error handling with `syncError` event
+
+For sync errors specifically, you can use the `syncError` collection event to handle all sync failures in one place. This is useful for showing toast notifications, logging, or retry logic:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+const users = db.collection<User>('users', {
+  syncers: {
+    create: async (doc) => { /* ... */ },
+    update: async (doc) => { /* ... */ },
+    remove: async (doc) => { /* ... */ },
+  },
+});
+
+// Centralized sync error handler
+users.on('syncError', (payload) => {
+  console.error('Sync failed:', payload);
+
+  // Show a notification to the user
+  showToast('Changes could not be saved. They have been reverted.');
+
+  // Log to an error tracking service
+  errorTracker.capture(new Error('GraphDB sync failure'), {
+    extra: payload,
+  });
+});
+```
+
+The `syncError` event fires for every sync failure, regardless of whether the caller catches the thrown error. This makes it a reliable place for cross-cutting concerns like logging or notifications.
+
+### Defensive reads before writes
+
+For operations where you expect a document might not exist, check before writing:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+async function safeUpdate(
+  id: string,
+  patch: Partial<User>,
+): Promise<Doc<User> | null> {
+  const existing = users.read(id);
+  if (!existing) {
+    console.warn(`Cannot update: user ${id} not found`);
+    return null;
+  }
+  return await users.update(id, patch);
+}
+
+async function safeRemove(id: string): Promise<boolean> {
+  if (!users.exists(id)) {
+    console.warn(`Cannot remove: user ${id} not found`);
+    return false;
+  }
+  const result = await users.remove(id);
+  return result.removed;
+}
+```
+
+### Validating populate data
+
+When hydrating a collection from an external source, validate the data shape before calling `populate()`:
+
+```ts
+type User = { name: string; email: string; age: number };
+
+function validateForPopulate(docs: unknown[]): Doc<User>[] {
+  return docs.map((doc, index) => {
+    if (typeof doc !== 'object' || doc === null) {
+      throw new Error(`Document at index ${index} is not an object`);
+    }
+    const d = doc as Record<string, unknown>;
+    if (!d._id || typeof d._id !== 'string') {
+      throw new Error(`Document at index ${index} is missing a valid _id`);
+    }
+    return d as Doc<User>;
+  });
+}
+
+const rawData = await fetchUsersFromAPI();
+const validated = validateForPopulate(rawData);
+users.populate(validated);
+```
+
+## Error behavior summary
+
+| Operation | Error condition | Side effect | Recovery |
+|---|---|---|---|
+| `update('', patch)` | Empty ID | None (throws before write) | Fix caller code |
+| `update(id, patch)` | ID not found | None (throws before write) | Check `exists(id)` first |
+| `remove('')` | Empty ID | None (throws before write) | Fix caller code |
+| `remove(id)` | ID not found | None (throws before write) | Check `exists(id)` first |
+| `populate([...])` | Missing `_id` | None (throws before write) | Ensure all docs have `_id` |
+| `create(doc)` | Sync failure | Doc removed (reverted) | Catch error or listen `syncError` |
+| `update(id, patch)` | Sync failure | Doc reverted to previous state | Catch error or listen `syncError` |
+| `remove(id)` | Sync failure | Doc re-inserted (reverted) | Catch error or listen `syncError` |
+
+The key distinction: **validation errors** throw before any mutation occurs, so there is nothing to revert. **Sync errors** throw after an optimistic write, and GraphDB automatically reverts the change before throwing.

--- a/apps/docs/src/content/docs/advanced/patterns.md
+++ b/apps/docs/src/content/docs/advanced/patterns.md
@@ -1,0 +1,519 @@
+---
+title: Patterns
+description: Common patterns and best practices for using GraphDB.
+---
+
+This page presents practical patterns for common use cases. Each pattern includes a description of the problem, the approach, and a working code example.
+
+## Offline-first pattern
+
+**Problem:** Your application needs to work without a network connection. Data should be available immediately on startup and sync back to the server when connectivity is restored.
+
+**Approach:** On app load, fetch data from your API and hydrate the collection with `populate()`. Configure syncers to push writes back to the server. If the network is down, the syncer will fail, GraphDB will revert the local change, and you can retry later.
+
+```ts
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+
+const users = db.collection<User>('users', {
+  indexes: ['email'],
+  syncers: {
+    create: async (doc) => {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(doc),
+      });
+      return res.ok;
+    },
+    update: async (doc) => {
+      const res = await fetch(`/api/users/${doc._id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(doc),
+      });
+      return res.ok;
+    },
+    remove: async (doc) => {
+      const res = await fetch(`/api/users/${doc._id}`, {
+        method: 'DELETE',
+      });
+      return res.ok;
+    },
+  },
+});
+
+// Hydrate on app startup
+async function initializeUsers() {
+  try {
+    const response = await fetch('/api/users');
+    const apiUsers = await response.json();
+
+    users.populate(
+      apiUsers.map((u: any) => ({
+        _id: u.id,
+        _createdAt: u.createdAt,
+        _updatedAt: u.updatedAt,
+        name: u.name,
+        email: u.email,
+        age: u.age,
+      })),
+    );
+
+    console.log(`Loaded ${users.count()} users`);
+  } catch (error) {
+    console.warn('Failed to load users from API, starting with empty store');
+  }
+}
+
+// Queue failed operations for retry
+const pendingWrites: Array<() => Promise<void>> = [];
+
+users.on('syncError', () => {
+  // In a real app, capture the operation details for retry
+  console.warn('Sync failed, operation will be retried when online');
+});
+
+async function retryPendingWrites() {
+  while (pendingWrites.length > 0) {
+    const operation = pendingWrites.shift()!;
+    try {
+      await operation();
+    } catch {
+      pendingWrites.unshift(operation);
+      break; // Still offline, stop retrying
+    }
+  }
+}
+```
+
+## Optimistic UI pattern
+
+**Problem:** You want the UI to feel instant. Users should see their changes immediately, even before the server confirms them. If the server rejects the change, the UI should revert.
+
+**Approach:** GraphDB's syncer system does this automatically. The write is applied to the in-memory store first (so the UI updates), then the syncer runs asynchronously. On failure, the write is reverted. Combine this with listeners to keep the UI in sync.
+
+```ts
+import { GraphDB, type Doc } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+
+const users = db.collection<User>('users', {
+  syncers: {
+    update: async (doc) => {
+      const res = await fetch(`/api/users/${doc._id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(doc),
+      });
+      return res.ok;
+    },
+  },
+});
+
+// UI state management
+let userList: Doc<User>[] = [];
+
+function renderUsers() {
+  // Your framework's render logic here
+  console.log('Rendering', userList.length, 'users');
+}
+
+// Listen for all changes and re-render
+users.on('created', () => {
+  userList = users.query({});
+  renderUsers();
+});
+
+users.on('updated', () => {
+  userList = users.query({});
+  renderUsers();
+});
+
+users.on('removed', () => {
+  userList = users.query({});
+  renderUsers();
+});
+
+// Handle sync failures -- the revert already happened,
+// but we need to re-render to reflect the reverted state
+users.on('syncError', () => {
+  userList = users.query({});
+  renderUsers();
+  showNotification('Your change could not be saved and was reverted.');
+});
+
+// User action: rename a user
+async function renameUser(id: string, newName: string) {
+  // This updates immediately (UI sees it right away via 'updated' listener)
+  // If the server rejects, it reverts (UI sees revert via 'syncError' listener)
+  try {
+    await users.update(id, { name: newName });
+  } catch {
+    // Error already handled by syncError listener,
+    // but you can add call-site-specific logic here
+  }
+}
+```
+
+The key insight is that you do not need to manage optimistic state yourself. GraphDB handles the write-then-revert lifecycle, and your listeners keep the UI synchronized with the actual store state.
+
+## Repository pattern
+
+**Problem:** You want to encapsulate data access logic behind a clean interface. Business rules, default values, derived fields, and validation should live in one place, not be scattered across your application.
+
+**Approach:** Wrap a GraphDB collection in a module or class that exposes domain-specific methods. The collection is an implementation detail.
+
+```ts
+import { GraphDB, type Doc } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+
+function createUserRepository() {
+  const collection = db.collection<User>('users', {
+    indexes: ['email', 'age'],
+  });
+
+  return {
+    // Domain-specific queries
+    findByEmail(email: string): Doc<User> | null {
+      return collection.findOne({ email });
+    },
+
+    findAdults(): Doc<User>[] {
+      return collection.query(
+        { age: { gte: 18 } },
+        { sort: { name: 'ASC' } },
+      );
+    },
+
+    findByAgeRange(min: number, max: number): Doc<User>[] {
+      return collection.query({}).filter(
+        (user) => user.age >= min && user.age <= max,
+      );
+    },
+
+    // Validated writes
+    async createUser(
+      name: string,
+      email: string,
+      age: number,
+    ): Promise<Doc<User>> {
+      // Business validation
+      if (age < 0 || age > 150) {
+        throw new Error(`Invalid age: ${age}`);
+      }
+      if (!email.includes('@')) {
+        throw new Error(`Invalid email: ${email}`);
+      }
+
+      // Check for duplicate email
+      const existing = collection.findOne({ email });
+      if (existing) {
+        throw new Error(`User with email ${email} already exists`);
+      }
+
+      return await collection.create({ name, email, age });
+    },
+
+    async updateEmail(id: string, newEmail: string): Promise<Doc<User>> {
+      if (!newEmail.includes('@')) {
+        throw new Error(`Invalid email: ${newEmail}`);
+      }
+
+      const duplicate = collection.findOne({ email: newEmail });
+      if (duplicate && duplicate._id !== id) {
+        throw new Error(`Email ${newEmail} is already taken`);
+      }
+
+      return await collection.update(id, { email: newEmail });
+    },
+
+    async deactivateUser(id: string): Promise<{ removed: boolean }> {
+      return await collection.remove(id);
+    },
+
+    // Statistics
+    countByAge(age: number): number {
+      return collection.count({ age });
+    },
+
+    totalUsers(): number {
+      return collection.count();
+    },
+
+    // Expose event subscription for the UI layer
+    onChange(callback: () => void) {
+      const cancelCreated = collection.on('created', callback);
+      const cancelUpdated = collection.on('updated', callback);
+      const cancelRemoved = collection.on('removed', callback);
+
+      // Return a single cancel function that removes all listeners
+      return () => {
+        cancelCreated();
+        cancelUpdated();
+        cancelRemoved();
+      };
+    },
+
+    // Hydration
+    populate(docs: Doc<User>[]) {
+      collection.populate(docs);
+    },
+  };
+}
+
+// Usage
+const userRepo = createUserRepository();
+
+await userRepo.createUser('Alice', 'alice@example.com', 25);
+const alice = userRepo.findByEmail('alice@example.com');
+const adults = userRepo.findAdults();
+const total = userRepo.totalUsers();
+```
+
+This pattern keeps your components and business logic clean. They interact with `userRepo.findByEmail()` instead of `collection.query({ email })`. Validation, defaults, and error messages are centralized.
+
+## Testing patterns
+
+**Problem:** You need to test code that uses GraphDB. You want tests to be isolated, fast, and deterministic.
+
+**Approach:** Create a fresh `GraphDB` instance per test. Synchronous reads need no mocking. For async writes with syncers, provide mock syncer functions.
+
+### Basic test setup
+
+```ts
+import { describe, it, expect } from 'bun:test';
+import { GraphDB, type Doc } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+describe('user operations', () => {
+  // Fresh database for each test -- complete isolation
+  function setup() {
+    const db = GraphDB();
+    const users = db.collection<User>('users', {
+      indexes: ['email'],
+    });
+    return { db, users };
+  }
+
+  it('creates and reads a user', async () => {
+    const { users } = setup();
+
+    const created = await users.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+      age: 25,
+    });
+
+    const found = users.read(created._id);
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe('Alice');
+  });
+
+  it('queries users by age', async () => {
+    const { users } = setup();
+
+    await users.create({ name: 'Alice', email: 'alice@example.com', age: 25 });
+    await users.create({ name: 'Bob', email: 'bob@example.com', age: 30 });
+    await users.create({ name: 'Carol', email: 'carol@example.com', age: 25 });
+
+    const age25 = users.query({ age: 25 });
+    expect(age25).toHaveLength(2);
+  });
+});
+```
+
+Since GraphDB is entirely in-memory with no external dependencies, each test gets a completely isolated database by calling `GraphDB()`. No teardown, no cleanup, no shared state between tests.
+
+### Testing with syncers
+
+When testing code that uses syncers, provide mock syncer functions that you control:
+
+```ts
+import { describe, it, expect } from 'bun:test';
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+describe('synced operations', () => {
+  it('syncs successfully when syncer returns true', async () => {
+    const db = GraphDB();
+    const users = db.collection<User>('users', {
+      syncers: {
+        create: async () => true, // Always succeeds
+      },
+    });
+
+    const doc = await users.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+      age: 25,
+    });
+
+    // Document exists because sync succeeded
+    expect(users.exists(doc._id)).toBe(true);
+  });
+
+  it('reverts on sync failure', async () => {
+    const db = GraphDB();
+    const users = db.collection<User>('users', {
+      syncers: {
+        create: async () => false, // Always fails
+      },
+    });
+
+    try {
+      await users.create({
+        name: 'Alice',
+        email: 'alice@example.com',
+        age: 25,
+      });
+    } catch {
+      // Expected: sync failure throws
+    }
+
+    // Document was reverted
+    expect(users.count()).toBe(0);
+  });
+
+  it('emits syncError event on failure', async () => {
+    const db = GraphDB();
+    const errors: unknown[] = [];
+
+    const users = db.collection<User>('users', {
+      syncers: {
+        create: async () => false,
+      },
+    });
+
+    users.on('syncError', (payload) => {
+      errors.push(payload);
+    });
+
+    try {
+      await users.create({
+        name: 'Alice',
+        email: 'alice@example.com',
+        age: 25,
+      });
+    } catch {
+      // Expected
+    }
+
+    expect(errors).toHaveLength(1);
+  });
+});
+```
+
+### Testing listeners
+
+Listeners fire synchronously during write operations, so you can assert on them immediately after the write:
+
+```ts
+import { describe, it, expect } from 'bun:test';
+import { GraphDB, type Doc } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+describe('listeners', () => {
+  it('fires created event with the new document', async () => {
+    const db = GraphDB();
+    const users = db.collection<User>('users');
+    const events: Doc<User>[] = [];
+
+    users.on('created', (payload) => {
+      events.push(payload.doc);
+    });
+
+    await users.create({ name: 'Alice', email: 'alice@example.com', age: 25 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe('Alice');
+  });
+
+  it('fires per-document listener on update', async () => {
+    const db = GraphDB();
+    const users = db.collection<User>('users');
+    let updatedDoc: Doc<User> | null = null;
+
+    const alice = await users.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+      age: 25,
+    });
+
+    users.listen(alice._id, (payload) => {
+      updatedDoc = payload.doc;
+    });
+
+    await users.update(alice._id, { age: 26 });
+
+    expect(updatedDoc).not.toBeNull();
+    expect(updatedDoc!.age).toBe(26);
+  });
+
+  it('supports O(1) unsubscribe', async () => {
+    const db = GraphDB();
+    const users = db.collection<User>('users');
+    let callCount = 0;
+
+    const cancel = users.on('created', () => {
+      callCount++;
+    });
+
+    await users.create({ name: 'Alice', email: 'alice@example.com', age: 25 });
+    expect(callCount).toBe(1);
+
+    cancel(); // Unsubscribe
+
+    await users.create({ name: 'Bob', email: 'bob@example.com', age: 30 });
+    expect(callCount).toBe(1); // Not incremented
+  });
+});
+```
+
+### Testing the repository pattern
+
+When you use the repository pattern, test the repository itself rather than the raw collection:
+
+```ts
+import { describe, it, expect } from 'bun:test';
+
+describe('user repository', () => {
+  it('rejects duplicate emails', async () => {
+    const userRepo = createUserRepository();
+
+    await userRepo.createUser('Alice', 'alice@example.com', 25);
+
+    expect(
+      userRepo.createUser('Bob', 'alice@example.com', 30),
+    ).rejects.toThrow('User with email alice@example.com already exists');
+  });
+
+  it('rejects invalid ages', () => {
+    const userRepo = createUserRepository();
+
+    expect(
+      userRepo.createUser('Alice', 'alice@example.com', -5),
+    ).rejects.toThrow('Invalid age: -5');
+  });
+});
+```
+
+## Summary
+
+| Pattern | When to use | Key benefit |
+|---|---|---|
+| Offline-first | App must work without network | Data available immediately, syncs when online |
+| Optimistic UI | UI must feel instant | Users see changes before server confirms |
+| Repository | Business logic needs a clean boundary | Validation and queries centralized in one place |
+| Testing | Always | No setup, no teardown, complete isolation per test |

--- a/apps/docs/src/content/docs/advanced/performance.md
+++ b/apps/docs/src/content/docs/advanced/performance.md
@@ -1,0 +1,181 @@
+---
+title: Performance
+description: Performance characteristics and complexity analysis.
+---
+
+GraphDB is an in-memory database, so all operations are fast. However, understanding the complexity characteristics helps you design your data model and decide when indexes are worth the memory cost.
+
+## Complexity reference
+
+### Read operations
+
+| Operation | Complexity | Notes |
+|---|---|---|
+| `read(id)` | O(1) | `Map.get()` |
+| `exists(id)` | O(1) | `Map.has()` |
+| `count()` (no filter) | O(1) | `Map.size` |
+| `count(where)` | O(n) | Delegates to `query()` |
+| `findOne(where)` | O(n) worst case | Stops at first match |
+| `query()` (no index) | O(n) | Full scan of all documents |
+| `query()` (indexed, equality/eq) | O(1) + O(k) | O(1) index lookup, O(k) candidate evaluation |
+| `query()` (indexed, `in` operator) | O(m) + O(k) | O(m) lookups (m = array size), O(k) candidate evaluation |
+
+Where **n** = total documents, **k** = matching candidates, **m** = size of the `in` array.
+
+### Write operations
+
+| Operation | Complexity | Notes |
+|---|---|---|
+| `create(doc)` | O(1) + O(i) | O(1) insert, O(i) index updates |
+| `update(id, patch)` | O(1) + O(i) | O(1) lookup + merge, O(i) index updates |
+| `remove(id)` | O(1) + O(i) | O(1) delete, O(i) index updates |
+| `updateMany(where, patch)` | O(n) + O(k) | O(n) query, O(k) sequential writes |
+| `removeMany(where)` | O(n) + O(k) | O(n) query, O(k) sequential writes |
+| `populate(docs)` | O(n) + O(n*i) | O(n) inserts, O(n*i) index rebuild |
+| `clear()` | O(1) | `Map.clear()` on docs and each index bucket |
+
+Where **i** = number of indexed fields.
+
+### Listener operations
+
+| Operation | Complexity | Notes |
+|---|---|---|
+| `on(event, handler)` | O(1) | `Set.add()` |
+| `listen(id, handler)` | O(1) | `Set.add()` |
+| Unsubscribe (cancel function) | O(1) | `Set.delete()` |
+
+### Sorting
+
+| Operation | Complexity | Notes |
+|---|---|---|
+| `sortDocuments()` | O(n log n) | Standard comparison sort |
+
+### Memory
+
+| Structure | Memory | Notes |
+|---|---|---|
+| Document storage | O(n) | One entry per document |
+| Index storage | O(n * i) | n = documents, i = indexed fields |
+| Per-index bucket | O(distinct values) | One `Set` per distinct value per field |
+
+## When indexes help
+
+Indexes accelerate queries that use **equality-based** lookups on the indexed field. They are most effective when:
+
+- You query frequently by a specific field (e.g., looking up users by `email`).
+- The field has high cardinality (many distinct values), so each index bucket is small.
+- You combine indexed fields in a query, because the query planner intersects candidate sets smallest-first.
+
+```ts
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+const users = db.collection<User>('users', {
+  indexes: ['email', 'age'],
+});
+
+// Fast: "email" is indexed, O(1) lookup
+const results = users.query({ email: 'alice@example.com' });
+
+// Fast: "age" is indexed, O(1) lookup per value in the array
+const youngUsers = users.query({ age: { in: [25, 26, 27] } });
+
+// Fast: both fields indexed, candidate sets are intersected
+const specific = users.query({ email: 'alice@example.com', age: 25 });
+```
+
+## When indexes do not help
+
+Indexes provide no benefit for:
+
+- **Range operators** (`gt`, `gte`, `lt`, `lte`): These require scanning values, not exact lookups. The query planner falls through to evaluating candidates or a full scan.
+- **`contains` and `regex` operators**: These cannot use hash-based lookups.
+- **Low-cardinality fields**: If a field only has a few distinct values (e.g., a `role` field with "admin" and "user"), the index buckets are large, reducing the filtering benefit.
+- **Write-heavy workloads with rarely-queried fields**: Every `create`, `update`, and `remove` must update all indexes. If you index a field you never filter by, you pay the write cost for no query benefit.
+
+```ts
+// NOT accelerated by index: range operator requires scan
+const adults = users.query({ age: { gt: 18 } });
+
+// NOT accelerated by index: regex cannot use hash lookup
+const matched = users.query({ name: { regex: /^Ali/ } });
+```
+
+## Index memory cost
+
+Each index maintains a `Map<value, Set<docId>>` for one field. The memory cost is proportional to the number of documents multiplied by the number of indexed fields.
+
+For a collection of 10,000 users with 2 indexed fields (`email` and `age`):
+
+- The `email` index stores up to 10,000 entries (one per unique email), each containing a `Set` with one `_id`.
+- The `age` index stores entries for each distinct age value. If ages range from 18 to 80, that is roughly 62 entries, each containing a `Set` with the `_id`s of users of that age.
+
+The overhead is modest for most in-memory use cases. If memory is a concern, only index fields you actually query by.
+
+## Practical guidance
+
+### Choosing what to index
+
+Ask yourself these questions:
+
+1. **Do I query this field frequently?** If you only filter by `email` once during app initialization, an index is unnecessary.
+2. **Is the filter an equality check?** Indexes only accelerate `eq`, primitive equality, and `in`. Range queries get no benefit.
+3. **Am I willing to pay the write overhead?** Each indexed field adds O(1) work per write. For 2-3 indexes this is negligible. For 10+ indexes on a write-heavy collection, measure first.
+
+### Batch operations
+
+Use `populate()` for loading initial data rather than calling `create()` in a loop. `populate()` inserts all documents first and rebuilds indexes once, rather than updating indexes per insert.
+
+```ts
+type User = { name: string; email: string; age: number };
+
+// Good: single populate call, indexes built once
+const apiData = await fetchUsers();
+users.populate(apiData.map((u) => ({
+  ...u,
+  _id: u.id,
+  _createdAt: u.createdAt,
+  _updatedAt: u.updatedAt,
+})));
+
+// Less efficient: N individual creates, N index rebuilds
+for (const u of apiData) {
+  await users.create(u);
+}
+```
+
+### Query optimization
+
+When combining filters, place indexed fields alongside non-indexed ones. The query planner will use the index to narrow down candidates before evaluating expensive checks:
+
+```ts
+// If "age" is indexed but "name" is not:
+// The planner uses the age index to find candidates,
+// then evaluates the regex only on those candidates.
+const results = users.query({
+  age: 25,
+  name: { regex: /^Ali/ },
+});
+```
+
+## When to use GraphDB
+
+GraphDB is a strong fit for:
+
+- **Prototyping and MVPs.** Zero configuration, no server, no schema files. Define a type and start storing data.
+- **Client-side caching.** Cache API responses in a queryable store with indexes for fast lookups.
+- **Offline-first applications.** Use `populate()` to hydrate from an API on startup, and syncers to push writes back when connectivity returns.
+- **Small to medium datasets.** Hundreds to low tens of thousands of documents per collection work comfortably in memory.
+- **Testing.** Create a fresh database per test with no setup or teardown. No mocking needed for synchronous read operations.
+
+## When to consider alternatives
+
+GraphDB is not designed for:
+
+- **Large datasets (100k+ documents).** All data lives in memory. There is no disk-backed storage, no pagination at the storage layer, and no streaming.
+- **Persistence requirements.** GraphDB is ephemeral. If the process restarts, data is gone unless you re-populate from an external source.
+- **Multi-process or multi-server.** There is no built-in replication, clustering, or shared memory. Each process gets its own independent in-memory store.
+- **Complex relational queries.** There are no joins, aggregations, or transactions. If your data model requires these, a relational database is more appropriate.
+- **Full-text search.** The `contains` and `regex` operators work but are O(n) scans. Dedicated search engines are better for large-scale text search.

--- a/apps/docs/src/content/docs/api-reference/collection.md
+++ b/apps/docs/src/content/docs/api-reference/collection.md
@@ -1,0 +1,566 @@
+---
+title: Collection
+description: API reference for all Collection methods.
+---
+
+A `Collection<T>` is the primary interface for storing, querying, and observing documents. Collections are created via `db.createCollection()` and retrieved via `db.getCollection()`.
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+db.createCollection<User>('users');
+const users = db.getCollection<User>('users')!;
+```
+
+---
+
+## Read Operations
+
+All read operations are **synchronous**.
+
+### read
+
+Returns a single document by its ID.
+
+```typescript
+read(id: string): Doc<T> | null;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | Yes | The `_id` of the document to retrieve. |
+
+#### Return Type
+
+`Doc<T> | null` -- The document if found, or `null` if no document exists with that ID.
+
+#### Example
+
+```typescript
+const id = await users.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+
+const doc = users.read(id);
+// { _id: '...', name: 'Alice', email: 'alice@example.com', age: 30, createdAt: 1700000000000, updatedAt: 1700000000000 }
+
+const missing = users.read('nonexistent-id');
+// null
+```
+
+---
+
+### query
+
+Returns all documents matching the given where clause, with optional sorting, pagination, and limiting.
+
+```typescript
+query(where: Where<T>, options?: QueryOptions): Doc<T>[];
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `where` | `Where<T>` | Yes | Filter criteria. Pass `{}` to match all documents. |
+| `options` | `QueryOptions` | No | Sorting, skip, and limit options. |
+
+#### QueryOptions
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `orderBy` | `Record<string, 'ASC' \| 'DESC'>` | Sort by one or more fields. |
+| `skip` | `number` | Number of results to skip (applied after sort). |
+| `limit` | `number` | Maximum number of results to return (applied after skip). |
+
+#### Return Type
+
+`Doc<T>[]` -- Always returns an array. Returns an empty array if no documents match.
+
+#### Behavior
+
+The query pipeline executes in this order: **filter** then **sort** then **skip** then **limit**.
+
+When indexed fields are present in the where clause with primitive equality, `eq`, or `in` operators, the index is used to narrow candidates before applying remaining filters. See [Where Clauses](/api-reference/where-clauses/) for full details.
+
+#### Example
+
+```typescript
+// Find all users older than 25, sorted by name
+const results = users.query(
+  { age: { gt: 25 } },
+  { orderBy: { name: 'ASC' }, limit: 10 }
+);
+
+// Find all documents (no filter)
+const all = users.query({});
+
+// Pagination
+const page2 = users.query({}, { orderBy: { createdAt: 'DESC' }, skip: 10, limit: 10 });
+```
+
+---
+
+### findOne
+
+Returns the first document matching the where clause.
+
+```typescript
+findOne(where: Where<T>): Doc<T> | null;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `where` | `Where<T>` | Yes | Filter criteria. |
+
+#### Return Type
+
+`Doc<T> | null` -- The first matching document, or `null` if none match.
+
+#### Example
+
+```typescript
+const alice = users.findOne({ email: 'alice@example.com' });
+// { _id: '...', name: 'Alice', email: 'alice@example.com', age: 30, ... }
+
+const nobody = users.findOne({ name: 'Nobody' });
+// null
+```
+
+---
+
+### count
+
+Returns the number of documents matching the where clause, or the total count if no where clause is provided.
+
+```typescript
+count(where?: Where<T>): number;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `where` | `Where<T>` | No | Filter criteria. Omit to count all documents. |
+
+#### Return Type
+
+`number`
+
+#### Example
+
+```typescript
+const total = users.count();
+// 42
+
+const adults = users.count({ age: { gte: 18 } });
+// 38
+```
+
+---
+
+### exists
+
+Checks whether a document with the given ID exists in the collection.
+
+```typescript
+exists(id: string): boolean;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | Yes | The `_id` of the document to check. |
+
+#### Return Type
+
+`boolean`
+
+#### Example
+
+```typescript
+const id = await users.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+
+users.exists(id);    // true
+users.exists('xxx'); // false
+```
+
+---
+
+## Write Operations
+
+All write operations are **asynchronous**. If a syncer is configured for the operation, the local write is applied optimistically and then the syncer runs. If the syncer returns `false` or throws, the local change is reverted and an error is thrown.
+
+### create
+
+Inserts a new document into the collection.
+
+```typescript
+create(doc: T): Promise<string>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `doc` | `T` | Yes | The document data (without `_id`, `createdAt`, or `updatedAt`). |
+
+#### Return Type
+
+`Promise<string>` -- Resolves with the generated `_id` of the new document.
+
+#### Behavior
+
+- Generates a unique `_id` via `crypto.randomUUID()`.
+- Sets `createdAt` and `updatedAt` to the current epoch milliseconds.
+- Updates any relevant indexes.
+- Emits a `create` event.
+- If a `create` syncer is configured and it returns `false` or throws, the document is removed from the collection and the error `"Document synchronization wasn't possible."` is thrown. A `syncError` event is also emitted.
+
+#### Example
+
+```typescript
+const id = await users.create({
+  name: 'Alice',
+  email: 'alice@example.com',
+  age: 30,
+});
+// id: 'a1b2c3d4-...'
+```
+
+---
+
+### update
+
+Updates an existing document by merging a partial patch.
+
+```typescript
+update(id: string, patch: Partial<T>): Promise<Doc<T>>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | Yes | The `_id` of the document to update. |
+| `patch` | `Partial<T>` | Yes | Fields to merge into the existing document. |
+
+#### Return Type
+
+`Promise<Doc<T>>` -- Resolves with the full updated document.
+
+#### Behavior
+
+- Merges the patch into the existing document.
+- Updates `updatedAt` to the current epoch milliseconds.
+- Updates any relevant indexes.
+- Emits an `update` event with `{ before, after, patch }`.
+
+#### Errors
+
+| Condition | Error Message |
+|-----------|---------------|
+| `id` is falsy | `"You must provide the GraphDocument ID that you would like to update."` |
+| No document found | `"No document to update found with ID: {id}"` |
+| Syncer returns `false` or throws | `"[UPDATE SYNC]: Document synchronization wasn't possible."` |
+
+When the update syncer fails, the document is reverted to its state before the update and a `syncError` event is emitted.
+
+#### Example
+
+```typescript
+const updated = await users.update(id, { age: 31 });
+// { _id: '...', name: 'Alice', email: 'alice@example.com', age: 31, createdAt: ..., updatedAt: ... }
+```
+
+---
+
+### remove
+
+Removes a document from the collection.
+
+```typescript
+remove(id: string): Promise<RemoveResult>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | Yes | The `_id` of the document to remove. |
+
+#### Return Type
+
+```typescript
+type RemoveResult = { removedId: string; acknowledge: true };
+```
+
+`Promise<RemoveResult>` -- Resolves with the removed document's ID and an acknowledgement flag.
+
+#### Errors
+
+| Condition | Error Message |
+|-----------|---------------|
+| `id` is falsy | `"You must provide the GraphDocument ID that you would like to remove."` |
+| No document found | `"No document to remove found with ID: {id}"` |
+| Syncer returns `false` or throws | `"[REMOVE SYNC]: Document synchronization wasn't possible."` |
+
+When the remove syncer fails, the document is restored to the collection and a `syncError` event is emitted.
+
+#### Example
+
+```typescript
+const result = await users.remove(id);
+// { removedId: 'a1b2c3d4-...', acknowledge: true }
+```
+
+---
+
+## Bulk Operations
+
+### populate
+
+Inserts an array of pre-existing documents (with `_id` already set) into the collection. Useful for hydrating the collection from an external data source.
+
+```typescript
+populate(docs: Doc<T>[]): void;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `docs` | `Doc<T>[]` | Yes | Array of complete documents including `_id`, `createdAt`, and `updatedAt`. |
+
+#### Return Type
+
+`void`
+
+#### Errors
+
+| Condition | Error Message |
+|-----------|---------------|
+| Any document is missing `_id` | `"Every document must have an _id for populate."` |
+
+#### Behavior
+
+- Adds each document to the collection's storage and indexes.
+- Emits a single `populate` event with `{ count }` after all documents are inserted.
+- Does **not** invoke syncers.
+
+#### Example
+
+```typescript
+const existingDocs = [
+  { _id: 'user-1', name: 'Alice', email: 'alice@example.com', age: 30, createdAt: 1700000000000, updatedAt: 1700000000000 },
+  { _id: 'user-2', name: 'Bob', email: 'bob@example.com', age: 25, createdAt: 1700000000000, updatedAt: 1700000000000 },
+];
+
+users.populate(existingDocs);
+// populate event emitted with { count: 2 }
+```
+
+---
+
+### updateMany
+
+Updates all documents matching the where clause with the given patch.
+
+```typescript
+updateMany(where: Where<T>, patch: Partial<T>): Promise<Doc<T>[]>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `where` | `Where<T>` | Yes | Filter criteria to select documents. |
+| `patch` | `Partial<T>` | Yes | Fields to merge into each matching document. |
+
+#### Return Type
+
+`Promise<Doc<T>[]>` -- Resolves with an array of the updated documents.
+
+#### Example
+
+```typescript
+// Give everyone over 30 a year older
+const updated = await users.updateMany({ age: { gt: 30 } }, { age: 31 });
+// Returns all updated documents
+```
+
+---
+
+### removeMany
+
+Removes all documents matching the where clause.
+
+```typescript
+removeMany(where: Where<T>): Promise<RemoveResult[]>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `where` | `Where<T>` | Yes | Filter criteria to select documents to remove. |
+
+#### Return Type
+
+`Promise<RemoveResult[]>` -- Resolves with an array of `RemoveResult` objects, one per removed document.
+
+#### Example
+
+```typescript
+// Remove all users under 18
+const results = await users.removeMany({ age: { lt: 18 } });
+// [{ removedId: '...', acknowledge: true }, ...]
+```
+
+---
+
+### clear
+
+Removes all documents from the collection, clearing all storage, indexes, and listeners.
+
+```typescript
+clear(): void;
+```
+
+#### Parameters
+
+None.
+
+#### Return Type
+
+`void`
+
+#### Example
+
+```typescript
+users.clear();
+users.count(); // 0
+```
+
+---
+
+## Event Operations
+
+### on
+
+Subscribes to collection-level events. Returns a cancel function to unsubscribe.
+
+```typescript
+on<E extends EventType>(event: E, fn: (payload: EventPayloadMap<T>[E]) => void): CancelFn;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `event` | `EventType` | Yes | The event to listen for: `'create'`, `'update'`, `'remove'`, `'populate'`, or `'syncError'`. |
+| `fn` | `(payload) => void` | Yes | Callback invoked when the event fires. |
+
+#### Event Payloads
+
+| Event | Payload Type | Fields |
+|-------|-------------|--------|
+| `'create'` | `CreatePayload<T>` | `{ doc }` |
+| `'update'` | `UpdatePayload<T>` | `{ before, after, patch }` |
+| `'remove'` | `RemovePayload<T>` | `{ doc }` |
+| `'populate'` | `PopulatePayload` | `{ count }` |
+| `'syncError'` | `SyncErrorPayload` | `{ op, error, docId? }` |
+
+#### Return Type
+
+`CancelFn` (`() => void`) -- Call this function to unsubscribe.
+
+#### Example
+
+```typescript
+// Listen for new documents
+const cancel = users.on('create', (payload) => {
+  console.log('New user created:', payload.doc.name);
+});
+
+// Listen for updates
+users.on('update', ({ before, after, patch }) => {
+  console.log(`User ${before.name} updated:`, patch);
+});
+
+// Listen for removals
+users.on('remove', ({ doc }) => {
+  console.log('User removed:', doc.name);
+});
+
+// Listen for populate
+users.on('populate', ({ count }) => {
+  console.log(`Populated ${count} documents`);
+});
+
+// Listen for sync errors
+users.on('syncError', ({ op, error, docId }) => {
+  console.error(`Sync failed for ${op} on ${docId}:`, error);
+});
+
+// Unsubscribe
+cancel();
+```
+
+---
+
+### listen
+
+Subscribes to changes on a specific document by its ID. The callback fires on create, update, and remove events that affect that document.
+
+```typescript
+listen(id: string, fn: (payload: ListenerPayload<T>) => void): CancelFn;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | Yes | The `_id` of the document to observe. |
+| `fn` | `(payload) => void` | Yes | Callback invoked when the document is created, updated, or removed. |
+
+#### Listener Payload
+
+```typescript
+type ListenerPayload<T> = CreatePayload<T> | UpdatePayload<T> | RemovePayload<T>;
+```
+
+The payload will be one of:
+- `{ doc }` for create events
+- `{ before, after, patch }` for update events
+- `{ doc }` for remove events
+
+#### Return Type
+
+`CancelFn` (`() => void`) -- Call this function to unsubscribe.
+
+#### Example
+
+```typescript
+const id = await users.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+
+const cancel = users.listen(id, (payload) => {
+  if ('before' in payload && 'after' in payload) {
+    console.log('Document updated:', payload.after);
+  } else {
+    console.log('Document changed:', payload.doc);
+  }
+});
+
+// Trigger the listener
+await users.update(id, { age: 31 });
+
+// Stop listening
+cancel();
+```

--- a/apps/docs/src/content/docs/api-reference/graphdb.md
+++ b/apps/docs/src/content/docs/api-reference/graphdb.md
@@ -1,0 +1,235 @@
+---
+title: GraphDB
+description: API reference for the GraphDB factory function.
+---
+
+## Factory Function
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+function GraphDB(): GraphDBType;
+```
+
+`GraphDB` is a factory function that creates and returns a new in-memory database instance. Each call produces an independent database with its own set of collections.
+
+### Return Type
+
+```typescript
+type GraphDBType = {
+  createCollection: <T>(name: string, options?: CollectionOptions<T>) => void;
+  getCollection: <T>(name: string) => Collection<T> | null;
+  listCollections: () => string[];
+  removeCollection: (name: string) => boolean;
+};
+```
+
+### Basic Usage
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+const db = GraphDB();
+```
+
+---
+
+## Methods
+
+### createCollection
+
+Registers a new collection in the database.
+
+```typescript
+createCollection<T>(name: string, options?: CollectionOptions<T>): void;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | Yes | Unique name for the collection. |
+| `options` | `CollectionOptions<T>` | No | Configuration for indexes and syncers. |
+
+#### CollectionOptions
+
+```typescript
+type CollectionOptions<T> = {
+  indexes?: (keyof T)[];
+  syncers?: Syncers<T>;
+};
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `indexes` | `(keyof T)[]` | Fields to build hash indexes on for faster equality, `eq`, and `in` lookups. |
+| `syncers` | `Syncers<T>` | Async callbacks invoked after create, update, or remove operations for external synchronization. |
+
+#### Return Type
+
+`void`
+
+#### Example
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+
+// Basic collection
+db.createCollection<User>('users');
+
+// Collection with indexes and syncers
+db.createCollection<User>('users', {
+  indexes: ['email', 'age'],
+  syncers: {
+    create: async (doc) => {
+      await fetch('/api/users', { method: 'POST', body: JSON.stringify(doc) });
+      return true;
+    },
+    update: async (doc) => {
+      await fetch(`/api/users/${doc._id}`, { method: 'PUT', body: JSON.stringify(doc) });
+      return true;
+    },
+    remove: async (docId) => {
+      await fetch(`/api/users/${docId}`, { method: 'DELETE' });
+      return true;
+    },
+  },
+});
+```
+
+---
+
+### getCollection
+
+Retrieves an existing collection by name.
+
+```typescript
+getCollection<T>(name: string): Collection<T> | null;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | Yes | The name of the collection to retrieve. |
+
+#### Return Type
+
+`Collection<T> | null` -- Returns the collection if it exists, or `null` if no collection with the given name has been created.
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+db.createCollection<User>('users');
+
+const users = db.getCollection<User>('users');
+// users is Collection<User>
+
+const missing = db.getCollection('nonexistent');
+// missing is null
+```
+
+---
+
+### listCollections
+
+Returns the names of all collections currently registered in the database.
+
+```typescript
+listCollections(): string[];
+```
+
+#### Parameters
+
+None.
+
+#### Return Type
+
+`string[]` -- An array of collection names.
+
+#### Example
+
+```typescript
+const db = GraphDB();
+
+db.createCollection('users');
+db.createCollection('posts');
+db.createCollection('comments');
+
+const names = db.listCollections();
+// ['users', 'posts', 'comments']
+```
+
+---
+
+### removeCollection
+
+Removes a collection from the database, including all of its data, indexes, and listeners.
+
+```typescript
+removeCollection(name: string): boolean;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | Yes | The name of the collection to remove. |
+
+#### Return Type
+
+`boolean` -- Returns `true` if the collection was found and removed, `false` if no collection with the given name exists.
+
+#### Example
+
+```typescript
+const db = GraphDB();
+db.createCollection('users');
+
+const removed = db.removeCollection('users');
+// true
+
+const removedAgain = db.removeCollection('users');
+// false (already removed)
+```
+
+---
+
+## Complete Example
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+
+// Create a collection with an index on email
+db.createCollection<User>('users', {
+  indexes: ['email'],
+});
+
+// Retrieve the collection
+const users = db.getCollection<User>('users');
+
+if (users) {
+  // Use collection methods
+  const id = await users.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+  const doc = users.read(id);
+  console.log(doc);
+}
+
+// List all collections
+console.log(db.listCollections()); // ['users']
+
+// Clean up
+db.removeCollection('users');
+console.log(db.listCollections()); // []
+```

--- a/apps/docs/src/content/docs/api-reference/types.md
+++ b/apps/docs/src/content/docs/api-reference/types.md
@@ -1,0 +1,533 @@
+---
+title: Types
+description: Complete reference for all exported TypeScript types.
+---
+
+All types are exported from `@graphdb/types` and re-exported from `@graphdb/core`.
+
+```typescript
+import type { Doc, Where, Collection, GraphDBType } from '@graphdb/core';
+```
+
+---
+
+## Document Types
+
+### Doc
+
+The base document type. Every document stored in a collection is wrapped with these system fields.
+
+```typescript
+type Doc<T> = {
+  _id: string;
+  createdAt: number;
+  updatedAt: number;
+} & T;
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | `string` | Unique identifier generated via `crypto.randomUUID()`. |
+| `createdAt` | `number` | Epoch milliseconds when the document was created. |
+| `updatedAt` | `number` | Epoch milliseconds when the document was last updated. |
+
+Timestamps are epoch milliseconds (`number`), not `Date` objects.
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+// A Doc<User> looks like:
+const doc: Doc<User> = {
+  _id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+  name: 'Alice',
+  email: 'alice@example.com',
+  age: 30,
+};
+```
+
+---
+
+### RemoveResult
+
+The result returned by `remove()` and each element in the array returned by `removeMany()`.
+
+```typescript
+type RemoveResult = {
+  removedId: string;
+  acknowledge: true;
+};
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `removedId` | `string` | The `_id` of the removed document. |
+| `acknowledge` | `true` | Always `true`, confirming the operation succeeded. |
+
+#### Example
+
+```typescript
+const result: RemoveResult = await users.remove(id);
+// { removedId: 'a1b2c3d4-...', acknowledge: true }
+```
+
+---
+
+## Query Types
+
+### Where
+
+The filter object used to match documents. Each key corresponds to a document field. Values can be a primitive (strict equality), a `RegExp`, or a `WhereClause` operator object.
+
+```typescript
+type Where<T = Record<string, unknown>> = {
+  [K in keyof T]?: T[K] | WhereClause<T[K]> | RegExp;
+} & Record<string, unknown>;
+```
+
+All specified fields must match for a document to be included (logical AND).
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+// Primitive equality
+const w1: Where<User> = { name: 'Alice' };
+
+// RegExp
+const w2: Where<User> = { email: /gmail\.com$/ };
+
+// Operator object
+const w3: Where<User> = { age: { gte: 18, lt: 65 } };
+
+// Multi-field
+const w4: Where<User> = { name: 'Alice', age: { gt: 25 } };
+```
+
+---
+
+### WhereClause
+
+An object containing one or more comparison operators for filtering a single field.
+
+```typescript
+type WhereClause<V = unknown> = {
+  eq?: V;
+  notEq?: V;
+  gt?: number;
+  gte?: number;
+  lt?: number;
+  lte?: number;
+  includes?: string;
+  startsWith?: string;
+  endsWith?: string;
+  match?: RegExp;
+  in?: V[];
+};
+```
+
+| Operator | Operand Type | Description |
+|----------|-------------|-------------|
+| `eq` | `V` | Strict equality (`===`). |
+| `notEq` | `V` | Strict inequality (`!==`). |
+| `gt` | `number` | Greater than. |
+| `gte` | `number` | Greater than or equal. |
+| `lt` | `number` | Less than. |
+| `lte` | `number` | Less than or equal. |
+| `includes` | `string` | Substring inclusion check. |
+| `startsWith` | `string` | String prefix check. |
+| `endsWith` | `string` | String suffix check. |
+| `match` | `RegExp` | Regular expression test. |
+| `in` | `V[]` | Value is in the given array. |
+
+All operators in a single clause must pass for the field to match.
+
+#### Example
+
+```typescript
+// Age between 18 and 65 (inclusive lower, exclusive upper)
+const clause: WhereClause<number> = { gte: 18, lt: 65 };
+
+// Name starts with "A" and is not "Adam"
+const nameClause: WhereClause<string> = { startsWith: 'A', notEq: 'Adam' };
+```
+
+---
+
+### QueryOptions
+
+Options for sorting and paginating query results.
+
+```typescript
+type QueryOptions = {
+  skip?: number;
+  limit?: number;
+  orderBy?: Record<string, 'ASC' | 'DESC'>;
+};
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `skip` | `number` | Number of results to skip after sorting. |
+| `limit` | `number` | Maximum number of results to return after skipping. |
+| `orderBy` | `Record<string, 'ASC' \| 'DESC'>` | Sort by one or more fields. Supports multi-field sorting. |
+
+The pipeline order is: **filter** then **sort** then **skip** then **limit**.
+
+#### Example
+
+```typescript
+// Get the second page of 10 users sorted by name ascending
+const options: QueryOptions = {
+  orderBy: { name: 'ASC' },
+  skip: 10,
+  limit: 10,
+};
+
+const results = users.query({}, options);
+```
+
+---
+
+## Collection Types
+
+### Collection
+
+The full interface for interacting with a collection of documents.
+
+```typescript
+type Collection<T> = {
+  read: (id: string) => Doc<T> | null;
+  query: (where: Where<T>, options?: QueryOptions) => Doc<T>[];
+  findOne: (where: Where<T>) => Doc<T> | null;
+  create: (doc: T) => Promise<string>;
+  update: (id: string, patch: Partial<T>) => Promise<Doc<T>>;
+  remove: (id: string) => Promise<RemoveResult>;
+  populate: (docs: Doc<T>[]) => void;
+  listen: (id: string, fn: (payload: ListenerPayload<T>) => void) => CancelFn;
+  on: <E extends EventType>(event: E, fn: (payload: EventPayloadMap<T>[E]) => void) => CancelFn;
+  count: (where?: Where<T>) => number;
+  exists: (id: string) => boolean;
+  clear: () => void;
+  updateMany: (where: Where<T>, patch: Partial<T>) => Promise<Doc<T>[]>;
+  removeMany: (where: Where<T>) => Promise<RemoveResult[]>;
+};
+```
+
+See the [Collection API reference](/api-reference/collection/) for detailed documentation of each method.
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+const users: Collection<User> = db.getCollection<User>('users')!;
+
+const id = await users.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+const doc = users.read(id);
+```
+
+---
+
+### CollectionOptions
+
+Configuration options passed when creating a collection.
+
+```typescript
+type CollectionOptions<T> = {
+  indexes?: (keyof T)[];
+  syncers?: Syncers<T>;
+};
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `indexes` | `(keyof T)[]` | Fields to create hash indexes on. Speeds up primitive equality, `eq`, and `in` lookups. |
+| `syncers` | `Syncers<T>` | Async callbacks for synchronizing writes with an external data source. |
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+const options: CollectionOptions<User> = {
+  indexes: ['email', 'age'],
+  syncers: {
+    create: async (doc) => {
+      const res = await fetch('/api/users', { method: 'POST', body: JSON.stringify(doc) });
+      return res.ok;
+    },
+  },
+};
+
+db.createCollection<User>('users', options);
+```
+
+---
+
+### CancelFn
+
+A function returned by `on()` and `listen()` that unsubscribes the listener when called.
+
+```typescript
+type CancelFn = () => void;
+```
+
+#### Example
+
+```typescript
+const cancel: CancelFn = users.on('create', ({ doc }) => {
+  console.log('Created:', doc.name);
+});
+
+// Later, stop listening
+cancel();
+```
+
+---
+
+## Syncer Types
+
+### Syncers
+
+Async callback functions invoked after write operations for external synchronization. Each syncer should return `true` on success and `false` on failure. Throwing an error is treated as failure.
+
+```typescript
+type Syncers<T> = {
+  create?: (doc: Doc<T>) => Promise<boolean>;
+  update?: (doc: Doc<T>) => Promise<boolean>;
+  remove?: (docId: string) => Promise<boolean>;
+};
+```
+
+| Syncer | Parameter | Description |
+|--------|-----------|-------------|
+| `create` | `doc: Doc<T>` | Called after a document is created. Receives the full document. |
+| `update` | `doc: Doc<T>` | Called after a document is updated. Receives the full updated document. |
+| `remove` | `docId: string` | Called after a document is removed. Receives the document's `_id`. |
+
+On failure, the local change is automatically reverted (optimistic write rollback) and a `syncError` event is emitted.
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+const syncers: Syncers<User> = {
+  create: async (doc) => {
+    const res = await fetch('/api/users', { method: 'POST', body: JSON.stringify(doc) });
+    return res.ok;
+  },
+  update: async (doc) => {
+    const res = await fetch(`/api/users/${doc._id}`, { method: 'PUT', body: JSON.stringify(doc) });
+    return res.ok;
+  },
+  remove: async (docId) => {
+    const res = await fetch(`/api/users/${docId}`, { method: 'DELETE' });
+    return res.ok;
+  },
+};
+
+db.createCollection<User>('users', { syncers });
+```
+
+---
+
+## Event Types
+
+### EventType
+
+A union of all supported event names.
+
+```typescript
+type EventType = 'create' | 'update' | 'remove' | 'populate' | 'syncError';
+```
+
+---
+
+### EventPayloadMap
+
+Maps each event type to its corresponding payload type. Used by `on()` for type-safe event handling.
+
+```typescript
+type EventPayloadMap<T> = {
+  create: CreatePayload<T>;
+  update: UpdatePayload<T>;
+  remove: RemovePayload<T>;
+  populate: PopulatePayload;
+  syncError: SyncErrorPayload;
+};
+```
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+// The type system ensures the callback receives the correct payload
+users.on('update', (payload: EventPayloadMap<User>['update']) => {
+  console.log(payload.before.name, '->', payload.after.name);
+});
+```
+
+---
+
+### CreatePayload
+
+Payload emitted with the `create` event.
+
+```typescript
+type CreatePayload<T> = {
+  doc: Doc<T>;
+};
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `doc` | `Doc<T>` | The newly created document. |
+
+---
+
+### UpdatePayload
+
+Payload emitted with the `update` event.
+
+```typescript
+type UpdatePayload<T> = {
+  before: Doc<T>;
+  after: Doc<T>;
+  patch: Partial<T>;
+};
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `before` | `Doc<T>` | The document before the update. |
+| `after` | `Doc<T>` | The document after the update. |
+| `patch` | `Partial<T>` | The partial object that was merged. |
+
+---
+
+### RemovePayload
+
+Payload emitted with the `remove` event.
+
+```typescript
+type RemovePayload<T> = {
+  doc: Doc<T>;
+};
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `doc` | `Doc<T>` | The document that was removed. |
+
+---
+
+### PopulatePayload
+
+Payload emitted with the `populate` event.
+
+```typescript
+type PopulatePayload = {
+  count: number;
+};
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `count` | `number` | The number of documents that were populated. |
+
+---
+
+### SyncErrorPayload
+
+Payload emitted with the `syncError` event when a syncer fails.
+
+```typescript
+type SyncErrorPayload = {
+  op: 'create' | 'update' | 'remove';
+  error: unknown;
+  docId?: string;
+};
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `op` | `'create' \| 'update' \| 'remove'` | The operation that failed to sync. |
+| `error` | `unknown` | The error that was thrown or the sync failure reason. |
+| `docId` | `string \| undefined` | The `_id` of the affected document, if available. |
+
+---
+
+### ListenerPayload
+
+The union type used for per-document listeners registered via `listen()`.
+
+```typescript
+type ListenerPayload<T> = CreatePayload<T> | UpdatePayload<T> | RemovePayload<T>;
+```
+
+The payload will be one of the three event payloads. You can discriminate between them by checking for the presence of specific fields:
+
+#### Example
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+users.listen(id, (payload: ListenerPayload<User>) => {
+  if ('before' in payload && 'after' in payload) {
+    // UpdatePayload
+    console.log('Updated:', payload.patch);
+  } else {
+    // CreatePayload or RemovePayload
+    console.log('Document:', payload.doc);
+  }
+});
+```
+
+---
+
+## Database Types
+
+### GraphDBType
+
+The return type of the `GraphDB()` factory function. Provides methods for managing collections.
+
+```typescript
+type GraphDBType = {
+  createCollection: <T>(name: string, options?: CollectionOptions<T>) => void;
+  getCollection: <T>(name: string) => Collection<T> | null;
+  listCollections: () => string[];
+  removeCollection: (name: string) => boolean;
+};
+```
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `createCollection` | `void` | Register a new collection. |
+| `getCollection` | `Collection<T> \| null` | Retrieve a collection by name, or `null` if it does not exist. |
+| `listCollections` | `string[]` | Get the names of all registered collections. |
+| `removeCollection` | `boolean` | Remove a collection. Returns `true` if it existed. |
+
+See the [GraphDB API reference](/api-reference/graphdb/) for detailed documentation of each method.
+
+#### Example
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+import type { GraphDBType } from '@graphdb/core';
+
+const db: GraphDBType = GraphDB();
+
+type User = { name: string; email: string; age: number };
+
+db.createCollection<User>('users', { indexes: ['email'] });
+const users = db.getCollection<User>('users')!;
+console.log(db.listCollections()); // ['users']
+db.removeCollection('users');
+```

--- a/apps/docs/src/content/docs/api-reference/where-clauses.md
+++ b/apps/docs/src/content/docs/api-reference/where-clauses.md
@@ -1,0 +1,327 @@
+---
+title: Where Clauses
+description: Complete reference for where clause syntax and operators.
+---
+
+Where clauses are used by `query()`, `findOne()`, `count()`, `updateMany()`, and `removeMany()` to filter documents. A where clause is an object where each key corresponds to a field on the document and the value defines the condition to match.
+
+```typescript
+type Where<T = Record<string, unknown>> = {
+  [K in keyof T]?: T[K] | WhereClause<T[K]> | RegExp;
+} & Record<string, unknown>;
+```
+
+## Matching Rules
+
+1. **All fields must match.** Every field specified in the where clause must pass for a document to be included in the result.
+2. **All operators in a clause must pass.** When using an operator object with multiple operators, every operator within that object must pass for the field to match. If any single operator fails, the entire field condition fails.
+
+---
+
+## Filter Forms
+
+There are three ways to filter on a field: primitive equality, top-level RegExp, and operator objects.
+
+### Primitive Equality
+
+Match a field by direct value comparison using strict equality (`===`).
+
+```typescript
+// Find users named Alice
+users.query({ name: 'Alice' });
+
+// Find users who are exactly 30
+users.query({ age: 30 });
+```
+
+**Index support:** Yes. When the field is indexed, a hash-map lookup is used instead of a full collection scan.
+
+---
+
+### Top-Level RegExp
+
+Pass a `RegExp` directly as the field value. The document's field value is converted to a string via `String(value)` and then tested against the regex.
+
+```typescript
+// Find users whose name starts with "A" (case-insensitive)
+users.query({ name: /^a/i });
+
+// Find users with a gmail address
+users.query({ email: /gmail\.com$/ });
+```
+
+**Index support:** No. A full scan is always performed for regex filters.
+
+---
+
+### Operator Object
+
+Pass an object containing one or more operators from the `WhereClause` type.
+
+```typescript
+type WhereClause<V = unknown> = {
+  eq?: V;
+  notEq?: V;
+  gt?: number;
+  gte?: number;
+  lt?: number;
+  lte?: number;
+  includes?: string;
+  startsWith?: string;
+  endsWith?: string;
+  match?: RegExp;
+  in?: V[];
+};
+```
+
+---
+
+## Operators
+
+### eq
+
+Tests for strict equality (`===`).
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | Same as the field type |
+| **Index support** | Yes |
+
+```typescript
+users.query({ name: { eq: 'Alice' } });
+```
+
+---
+
+### notEq
+
+Tests for strict inequality (`!==`).
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | Same as the field type |
+| **Index support** | No |
+
+```typescript
+users.query({ name: { notEq: 'Bob' } });
+```
+
+---
+
+### gt
+
+Tests that the field value is greater than the operand. Only passes when the field value is of type `number`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `number` |
+| **Index support** | No |
+
+```typescript
+users.query({ age: { gt: 25 } });
+```
+
+---
+
+### gte
+
+Tests that the field value is greater than or equal to the operand. Only passes when the field value is of type `number`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `number` |
+| **Index support** | No |
+
+```typescript
+users.query({ age: { gte: 18 } });
+```
+
+---
+
+### lt
+
+Tests that the field value is less than the operand. Only passes when the field value is of type `number`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `number` |
+| **Index support** | No |
+
+```typescript
+users.query({ age: { lt: 65 } });
+```
+
+---
+
+### lte
+
+Tests that the field value is less than or equal to the operand. Only passes when the field value is of type `number`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `number` |
+| **Index support** | No |
+
+```typescript
+users.query({ age: { lte: 30 } });
+```
+
+---
+
+### includes
+
+Tests that the field value (as a string) contains the operand substring. Only passes when the field value is of type `string`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `string` |
+| **Index support** | No |
+
+```typescript
+users.query({ email: { includes: 'example' } });
+```
+
+---
+
+### startsWith
+
+Tests that the field value (as a string) starts with the operand. Only passes when the field value is of type `string`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `string` |
+| **Index support** | No |
+
+```typescript
+users.query({ name: { startsWith: 'Al' } });
+```
+
+---
+
+### endsWith
+
+Tests that the field value (as a string) ends with the operand. Only passes when the field value is of type `string`.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `string` |
+| **Index support** | No |
+
+```typescript
+users.query({ email: { endsWith: '.com' } });
+```
+
+---
+
+### match
+
+Tests the field value against a `RegExp` using `RegExp.test()`. This is the operator-object equivalent of the top-level RegExp form.
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `RegExp` |
+| **Index support** | No |
+
+```typescript
+users.query({ name: { match: /^alice$/i } });
+```
+
+---
+
+### in
+
+Tests that the field value is included in the provided array (using `Array.includes()`).
+
+| Property | Value |
+|----------|-------|
+| **Operand type** | `V[]` (array of the field's type) |
+| **Index support** | Yes (union of index sets) |
+
+```typescript
+users.query({ age: { in: [25, 30, 35] } });
+users.query({ name: { in: ['Alice', 'Bob'] } });
+```
+
+---
+
+## Operator Evaluation Order
+
+When a field's value is an operator object, the operators are evaluated in the following order. Evaluation short-circuits on the first failure.
+
+1. `match` (RegExp test)
+2. `in` (array inclusion)
+3. `eq` (strict equality)
+4. `notEq` (strict inequality)
+5. `gt` (greater than)
+6. `gte` (greater than or equal)
+7. `lt` (less than)
+8. `lte` (less than or equal)
+9. `includes` (substring check)
+10. `startsWith` (prefix check)
+11. `endsWith` (suffix check)
+
+---
+
+## Combining Operators
+
+You can combine multiple operators in a single clause object. All operators must pass for the field to match.
+
+```typescript
+// Age must be >= 18 AND < 65
+users.query({ age: { gte: 18, lt: 65 } });
+
+// Name must start with "A" AND not equal "Adam"
+users.query({ name: { startsWith: 'A', notEq: 'Adam' } });
+```
+
+---
+
+## Multi-Field Queries
+
+When multiple fields are specified, all conditions must be satisfied (logical AND across fields).
+
+```typescript
+// Name starts with "A" AND age is between 18 and 65 AND email ends with ".com"
+const results = users.query({
+  name: { startsWith: 'A' },
+  age: { gte: 18, lt: 65 },
+  email: { endsWith: '.com' },
+});
+```
+
+---
+
+## Index Utilization
+
+Hash indexes are maintained as `Map<field, Map<value, Set<docId>>>`. They accelerate lookups for the following patterns only:
+
+| Pattern | Indexed? | Description |
+|---------|----------|-------------|
+| Primitive equality (`{ field: value }`) | Yes | Direct hash-map lookup. |
+| `eq` operator (`{ field: { eq: value } }`) | Yes | Direct hash-map lookup. |
+| `in` operator (`{ field: { in: [v1, v2] } }`) | Yes | Union of sets for each value. |
+| All other operators | No | Full scan on candidates. |
+
+When a query involves multiple indexed fields, the candidate sets are intersected starting from the smallest set. Any remaining non-indexed operators are then evaluated against the candidate documents.
+
+### Example with Indexes
+
+```typescript
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+db.createCollection<User>('users', {
+  indexes: ['email', 'age'],
+});
+
+const users = db.getCollection<User>('users')!;
+
+// Uses the email index for O(1) lookup, then checks age on candidates
+users.query({ email: 'alice@example.com', age: { gt: 25 } });
+
+// Uses the age index with "in" (union of sets for 25 and 30)
+users.query({ age: { in: [25, 30] } });
+
+// No index used -- startsWith requires a full scan
+users.query({ email: { startsWith: 'alice' } });
+```

--- a/apps/docs/src/content/docs/examples/backend-sync.md
+++ b/apps/docs/src/content/docs/examples/backend-sync.md
@@ -1,0 +1,315 @@
+---
+title: Backend Sync
+description: Full syncer implementation with a REST API backend.
+---
+
+GraphDB syncers let you persist writes to a backend while keeping the local collection as the source of truth for reads. Writes are optimistic: the local collection updates immediately, and if the syncer returns `false` or throws, the change is automatically reverted.
+
+## Defining the API layer
+
+```typescript
+const API_BASE = "https://api.example.com";
+
+interface Product {
+  name: string;
+  price: number;
+  category: string;
+  inStock: boolean;
+}
+```
+
+## Building the syncers
+
+Each syncer receives the document (or document ID for `remove`) and must return a `Promise<boolean>`. Return `true` to confirm the write, or `false` to trigger a revert.
+
+```typescript
+import { GraphDB, type Doc } from "@graphdb/core";
+
+const productSyncers = {
+  create: async (doc: Doc<Product>): Promise<boolean> => {
+    const response = await fetch(`${API_BASE}/products`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: doc._id,
+        name: doc.name,
+        price: doc.price,
+        category: doc.category,
+        inStock: doc.inStock,
+      }),
+    });
+
+    return response.ok;
+  },
+
+  update: async (doc: Doc<Product>): Promise<boolean> => {
+    const response = await fetch(`${API_BASE}/products/${doc._id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: doc.name,
+        price: doc.price,
+        category: doc.category,
+        inStock: doc.inStock,
+      }),
+    });
+
+    return response.ok;
+  },
+
+  remove: async (docId: string): Promise<boolean> => {
+    const response = await fetch(`${API_BASE}/products/${docId}`, {
+      method: "DELETE",
+    });
+
+    return response.ok;
+  },
+};
+```
+
+## Creating the collection with syncers
+
+```typescript
+const db = GraphDB();
+
+const products = db.createCollection<Product>("products", {
+  indexes: ["category", "inStock"],
+  syncers: productSyncers,
+});
+```
+
+## The optimistic write flow
+
+When you call a write method on a collection that has syncers, the following happens:
+
+1. The local collection is updated immediately (optimistic write).
+2. The corresponding syncer function is called in the background.
+3. If the syncer returns `true`, nothing else happens -- the local state is already correct.
+4. If the syncer returns `false` or throws, the local change is reverted and a `syncError` event is emitted.
+
+```typescript
+// This updates the local collection right away.
+// The UI can read the new document immediately.
+const id = await products.create({
+  name: "Mechanical Keyboard",
+  price: 149.99,
+  category: "peripherals",
+  inStock: true,
+});
+
+// The document is available in the collection synchronously after create resolves.
+const keyboard = products.read(id);
+// { _id: "...", name: "Mechanical Keyboard", price: 149.99, ... }
+```
+
+## Handling sync errors
+
+Subscribe to the `syncError` event to log failures, show notifications, or implement retry logic.
+
+```typescript
+products.on("syncError", ({ op, error, docId }) => {
+  console.error(`Sync failed for ${op} on doc ${docId}:`, error);
+});
+```
+
+### Retry with backoff
+
+A more robust approach retries failed operations with exponential backoff.
+
+```typescript
+interface FailedOp {
+  op: "create" | "update" | "remove";
+  docId?: string;
+  retries: number;
+}
+
+const failedOps: FailedOp[] = [];
+const MAX_RETRIES = 3;
+
+products.on("syncError", ({ op, docId }) => {
+  const existing = failedOps.find(
+    (f) => f.op === op && f.docId === docId,
+  );
+
+  if (existing) {
+    existing.retries += 1;
+  } else {
+    failedOps.push({ op, docId, retries: 1 });
+  }
+});
+
+async function retryFailedOps() {
+  const pending = failedOps.splice(0, failedOps.length);
+
+  for (const failed of pending) {
+    if (failed.retries > MAX_RETRIES) {
+      console.error(
+        `Giving up on ${failed.op} for doc ${failed.docId} after ${MAX_RETRIES} retries`,
+      );
+      continue;
+    }
+
+    const delay = Math.pow(2, failed.retries) * 1000;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    try {
+      if (failed.op === "create" && failed.docId) {
+        const doc = products.read(failed.docId);
+        if (doc) {
+          await productSyncers.create(doc);
+        }
+      } else if (failed.op === "update" && failed.docId) {
+        const doc = products.read(failed.docId);
+        if (doc) {
+          await productSyncers.update(doc);
+        }
+      } else if (failed.op === "remove" && failed.docId) {
+        await productSyncers.remove(failed.docId);
+      }
+    } catch (err) {
+      console.error(`Retry failed for ${failed.op}:`, err);
+      failedOps.push(failed); // re-queue for next cycle
+    }
+  }
+}
+
+// Run retry loop on an interval
+setInterval(retryFailedOps, 30_000);
+```
+
+## Populate on load
+
+A common pattern is to fetch existing data from the server when the app starts and load it into the collection with `populate`. This avoids triggering individual syncer calls for each document.
+
+```typescript
+interface ApiProduct {
+  id: string;
+  name: string;
+  price: number;
+  category: string;
+  inStock: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+async function loadProducts() {
+  const response = await fetch(`${API_BASE}/products`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load products: ${response.status}`);
+  }
+
+  const data: ApiProduct[] = await response.json();
+
+  // Map API response to the shape your collection expects.
+  // populate() bypasses syncers, so this will not POST back to the server.
+  await products.populate(
+    data.map((item) => ({
+      name: item.name,
+      price: item.price,
+      category: item.category,
+      inStock: item.inStock,
+    })),
+  );
+
+  console.log(`Loaded ${data.length} products from server`);
+}
+
+// Call on app startup
+loadProducts();
+```
+
+`populate` fires a single `populate` event with the count of inserted documents, rather than individual `create` events. This makes it efficient for bulk loading.
+
+## Full example: putting it all together
+
+```typescript
+import { GraphDB, type Doc } from "@graphdb/core";
+
+// --- Types ---
+interface Product {
+  name: string;
+  price: number;
+  category: string;
+  inStock: boolean;
+}
+
+// --- API ---
+const API_BASE = "https://api.example.com";
+
+// --- Syncers ---
+const syncers = {
+  create: async (doc: Doc<Product>): Promise<boolean> => {
+    const res = await fetch(`${API_BASE}/products`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(doc),
+    });
+    return res.ok;
+  },
+  update: async (doc: Doc<Product>): Promise<boolean> => {
+    const res = await fetch(`${API_BASE}/products/${doc._id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(doc),
+    });
+    return res.ok;
+  },
+  remove: async (docId: string): Promise<boolean> => {
+    const res = await fetch(`${API_BASE}/products/${docId}`, {
+      method: "DELETE",
+    });
+    return res.ok;
+  },
+};
+
+// --- Database ---
+const db = GraphDB();
+const products = db.createCollection<Product>("products", {
+  indexes: ["category", "inStock"],
+  syncers,
+});
+
+// --- Error handling ---
+products.on("syncError", ({ op, error, docId }) => {
+  console.error(`[sync] ${op} failed for ${docId}:`, error);
+});
+
+// --- Load initial data ---
+async function init() {
+  const res = await fetch(`${API_BASE}/products`);
+  if (res.ok) {
+    const data = await res.json();
+    await products.populate(data);
+  }
+}
+
+// --- Application code ---
+async function main() {
+  await init();
+
+  // Create a product -- written locally, then synced to server
+  const id = await products.create({
+    name: "USB-C Hub",
+    price: 39.99,
+    category: "peripherals",
+    inStock: true,
+  });
+
+  // Read is synchronous and instant
+  const hub = products.read(id);
+  console.log("Created:", hub?.name);
+
+  // Update -- local first, then PUT to server
+  await products.update(id, { price: 34.99 });
+
+  // Query
+  const peripherals = products.query({ category: "peripherals", inStock: true });
+  console.log("In-stock peripherals:", peripherals.length);
+
+  // Remove -- local first, then DELETE on server
+  await products.remove(id);
+}
+
+main();
+```

--- a/apps/docs/src/content/docs/examples/basic-usage.md
+++ b/apps/docs/src/content/docs/examples/basic-usage.md
@@ -1,0 +1,348 @@
+---
+title: Basic Usage
+description: Complete user management example from start to finish.
+---
+
+A complete walkthrough of GraphDB features using a user management scenario. Every snippet below is self-contained and runnable.
+
+## Setup
+
+```typescript
+import { GraphDB } from "@graphdb/core";
+
+interface User {
+  name: string;
+  email: string;
+  role: "admin" | "editor" | "viewer";
+  age: number;
+  active: boolean;
+}
+
+const db = GraphDB();
+
+const users = db.createCollection<User>("users", {
+  indexes: ["email", "role", "active"],
+});
+```
+
+Indexes on `email`, `role`, and `active` speed up equality and `in` lookups on those fields. Other operators still work on any field -- they just fall back to a full scan.
+
+## Creating documents
+
+`create` is async and returns the generated `_id`.
+
+```typescript
+const aliceId = await users.create({
+  name: "Alice Johnson",
+  email: "alice@example.com",
+  role: "admin",
+  age: 34,
+  active: true,
+});
+// aliceId -> "a1b2c3d4-..." (crypto.randomUUID)
+
+const bobId = await users.create({
+  name: "Bob Smith",
+  email: "bob@example.com",
+  role: "editor",
+  age: 28,
+  active: true,
+});
+
+const carolId = await users.create({
+  name: "Carol White",
+  email: "carol@example.com",
+  role: "viewer",
+  age: 41,
+  active: false,
+});
+
+const daveId = await users.create({
+  name: "Dave Park",
+  email: "dave@example.com",
+  role: "editor",
+  age: 25,
+  active: true,
+});
+```
+
+Every document stored in the collection is wrapped in `Doc<User>`, which adds `_id`, `createdAt`, and `updatedAt` (epoch milliseconds).
+
+## Reading a single document
+
+`read` is synchronous and returns `Doc<User> | null`.
+
+```typescript
+const alice = users.read(aliceId);
+// {
+//   _id: "a1b2c3d4-...",
+//   createdAt: 1739712000000,
+//   updatedAt: 1739712000000,
+//   name: "Alice Johnson",
+//   email: "alice@example.com",
+//   role: "admin",
+//   age: 34,
+//   active: true,
+// }
+
+const ghost = users.read("nonexistent-id");
+// null
+```
+
+## Querying with where clauses
+
+### Primitive equality
+
+The simplest filter is a plain value match.
+
+```typescript
+const admins = users.query({ role: "admin" });
+// [ Doc<User> for Alice ]
+```
+
+### Comparison operators
+
+```typescript
+const over30 = users.query({ age: { gt: 30 } });
+// [ Alice (34), Carol (41) ]
+
+const under35 = users.query({ age: { lt: 35 } });
+// [ Bob (28), Alice (34), Dave (25) ]
+
+const exactly28 = users.query({ age: { eq: 28 } });
+// [ Bob ]
+```
+
+### String operators
+
+```typescript
+const startsWithD = users.query({ name: { startsWith: "D" } });
+// [ Dave Park ]
+
+const gmailUsers = users.query({ email: { endsWith: "@example.com" } });
+// [ Alice, Bob, Carol, Dave ]
+
+const containsSmith = users.query({ name: { includes: "Smith" } });
+// [ Bob Smith ]
+```
+
+### RegExp matching
+
+You can pass a RegExp directly as a top-level where value, or use the `match` operator.
+
+```typescript
+// Top-level RegExp
+const matchJ = users.query({ name: /johnson/i });
+// [ Alice Johnson ]
+
+// match operator
+const matchPark = users.query({ name: { match: /park$/i } });
+// [ Dave Park ]
+```
+
+### The `in` operator
+
+```typescript
+const editorsAndViewers = users.query({ role: { in: ["editor", "viewer"] } });
+// [ Bob, Carol, Dave ]
+```
+
+### Combining multiple fields
+
+All fields in a where clause are ANDed together.
+
+```typescript
+const activeEditors = users.query({ role: "editor", active: true });
+// [ Bob, Dave ]
+```
+
+## Query options: sorting, skip, and limit
+
+```typescript
+// Sort by age descending
+const byAge = users.query({}, { orderBy: { age: "DESC" } });
+// [ Carol (41), Alice (34), Bob (28), Dave (25) ]
+
+// Pagination: page 1, 2 items per page
+const page1 = users.query(
+  {},
+  { orderBy: { name: "ASC" }, limit: 2, skip: 0 },
+);
+// [ Alice Johnson, Bob Smith ]
+
+// Page 2
+const page2 = users.query(
+  {},
+  { orderBy: { name: "ASC" }, limit: 2, skip: 2 },
+);
+// [ Carol White, Dave Park ]
+```
+
+## findOne
+
+Returns the first matching document or `null`. Useful when you expect exactly one result.
+
+```typescript
+const admin = users.findOne({ role: "admin" });
+// Doc<User> for Alice
+
+const missing = users.findOne({ role: "superadmin" });
+// null
+```
+
+## count and exists
+
+```typescript
+const totalUsers = users.count();
+// 4
+
+const activeCount = users.count({ active: true });
+// 3
+
+const aliceExists = users.exists(aliceId);
+// true
+
+const ghostExists = users.exists("nonexistent-id");
+// false
+```
+
+## Updating a document
+
+`update` is async and returns the full updated document.
+
+```typescript
+const updatedCarol = await users.update(carolId, { active: true, age: 42 });
+// {
+//   _id: "...",
+//   createdAt: 1739712000000,
+//   updatedAt: 1739712060000,   <-- updated
+//   name: "Carol White",
+//   email: "carol@example.com",
+//   role: "viewer",
+//   age: 42,                    <-- changed
+//   active: true,               <-- changed
+// }
+```
+
+Only the fields you pass in the patch are changed. `updatedAt` is bumped automatically.
+
+## Bulk operations
+
+### updateMany
+
+```typescript
+await users.updateMany({ role: "editor" }, { active: false });
+// Bob and Dave are now inactive
+```
+
+### removeMany
+
+```typescript
+const result = await users.removeMany({ active: false });
+// Removes Bob and Dave
+```
+
+## Removing a document
+
+```typescript
+const removeResult = await users.remove(aliceId);
+// { removedId: "a1b2c3d4-...", acknowledge: true }
+```
+
+## Listening to events
+
+### Collection-level events
+
+```typescript
+const unsubCreate = users.on("create", ({ doc }) => {
+  console.log("New user:", doc.name);
+});
+
+const unsubUpdate = users.on("update", ({ before, after, patch }) => {
+  console.log(`Updated ${before.name}:`, patch);
+});
+
+const unsubRemove = users.on("remove", ({ doc }) => {
+  console.log("Removed user:", doc.name);
+});
+
+// Trigger the listeners
+await users.create({
+  name: "Eve Turner",
+  email: "eve@example.com",
+  role: "viewer",
+  age: 30,
+  active: true,
+});
+// Console: "New user: Eve Turner"
+
+// Unsubscribe when done
+unsubCreate();
+unsubUpdate();
+unsubRemove();
+```
+
+### Per-document listeners
+
+```typescript
+const eveId = (await users.findOne({ name: /eve/i }))?._id;
+
+if (eveId) {
+  const cancel = users.listen(eveId, (doc) => {
+    console.log("Eve changed:", doc);
+  });
+
+  await users.update(eveId, { role: "editor" });
+  // Console: "Eve changed: { _id: ..., name: 'Eve Turner', role: 'editor', ... }"
+
+  cancel(); // stop listening
+}
+```
+
+## Populating initial data
+
+`populate` inserts many documents at once and fires a single `populate` event instead of individual `create` events.
+
+```typescript
+users.on("populate", ({ count }) => {
+  console.log(`Loaded ${count} users`);
+});
+
+await users.populate([
+  {
+    name: "Frank Lee",
+    email: "frank@example.com",
+    role: "viewer",
+    age: 22,
+    active: true,
+  },
+  {
+    name: "Grace Kim",
+    email: "grace@example.com",
+    role: "admin",
+    age: 37,
+    active: true,
+  },
+]);
+// Console: "Loaded 2 users"
+```
+
+## Clearing a collection
+
+```typescript
+await users.clear();
+
+const afterClear = users.count();
+// 0
+```
+
+## Retrieving a collection later
+
+If another part of your application needs access to an existing collection, use `getCollection`.
+
+```typescript
+const usersAgain = db.getCollection<User>("users");
+// Collection<User> | null
+```
+
+This returns the same collection instance -- no data is duplicated.

--- a/apps/docs/src/content/docs/examples/real-time-ui.md
+++ b/apps/docs/src/content/docs/examples/real-time-ui.md
@@ -1,0 +1,266 @@
+---
+title: Real-Time UI
+description: React example using GraphDB listeners for live UI updates.
+---
+
+GraphDB's event system makes it straightforward to keep a UI in sync with your data. This example builds a todo list in React, but the same pattern works with any React renderer -- React DOM, React Native, or any other target.
+
+## Database setup
+
+Create the database and collection outside of your component tree so they are shared singletons.
+
+```typescript
+// db.ts
+import { GraphDB } from "@graphdb/core";
+
+export interface Todo {
+  title: string;
+  completed: boolean;
+}
+
+export const db = GraphDB();
+
+export const todos = db.createCollection<Todo>("todos", {
+  indexes: ["completed"],
+});
+```
+
+## Custom hook: useCollection
+
+This hook subscribes to collection events and re-queries whenever the data changes. It returns the current list of documents plus the collection instance for writes.
+
+```typescript
+// useCollection.ts
+import { useState, useEffect, useCallback } from "react";
+import type { Collection, Doc, Where, QueryOptions } from "@graphdb/core";
+
+export function useCollection<T extends Record<string, unknown>>(
+  collection: Collection<T>,
+  where: Where<T> = {},
+  options?: QueryOptions<T>,
+) {
+  const [docs, setDocs] = useState<Doc<T>[]>(() =>
+    collection.query(where, options),
+  );
+
+  const refresh = useCallback(() => {
+    setDocs(collection.query(where, options));
+  }, [collection, where, options]);
+
+  useEffect(() => {
+    // Run an initial query in case the data changed between render and effect
+    refresh();
+
+    const unsubCreate = collection.on("create", refresh);
+    const unsubUpdate = collection.on("update", refresh);
+    const unsubRemove = collection.on("remove", refresh);
+    const unsubPopulate = collection.on("populate", refresh);
+
+    return () => {
+      unsubCreate();
+      unsubUpdate();
+      unsubRemove();
+      unsubPopulate();
+    };
+  }, [collection, refresh]);
+
+  return { docs, collection };
+}
+```
+
+Every time a `create`, `update`, `remove`, or `populate` event fires, the hook re-runs the query and React re-renders with the new data. The cleanup function unsubscribes all listeners when the component unmounts.
+
+## TodoList component
+
+```tsx
+// TodoList.tsx
+import { useState } from "react";
+import { useCollection } from "./useCollection";
+import { todos, type Todo } from "./db";
+
+export function TodoList() {
+  const [input, setInput] = useState("");
+
+  const { docs, collection } = useCollection<Todo>(todos, {}, {
+    orderBy: { createdAt: "DESC" },
+  });
+
+  const handleAdd = async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    await collection.create({ title: trimmed, completed: false });
+    setInput("");
+  };
+
+  const handleToggle = async (id: string, current: boolean) => {
+    await collection.update(id, { completed: !current });
+  };
+
+  const handleDelete = async (id: string) => {
+    await collection.remove(id);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleAdd();
+    }
+  };
+
+  const total = docs.length;
+  const done = docs.filter((d) => d.completed).length;
+
+  return (
+    <div>
+      <h1>Todos ({done}/{total} completed)</h1>
+
+      <div>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="What needs to be done?"
+        />
+        <button onClick={handleAdd}>Add</button>
+      </div>
+
+      <ul>
+        {docs.map((todo) => (
+          <li key={todo._id}>
+            <input
+              type="checkbox"
+              checked={todo.completed}
+              onChange={() => handleToggle(todo._id, todo.completed)}
+            />
+            <span
+              style={{
+                textDecoration: todo.completed ? "line-through" : "none",
+              }}
+            >
+              {todo.title}
+            </span>
+            <button onClick={() => handleDelete(todo._id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+Because `useCollection` handles all the subscription logic, the component itself contains no manual state synchronization. Adding, toggling, or deleting a todo triggers a collection event, which causes the hook to re-query and React to re-render.
+
+## Filtered views
+
+You can render multiple views of the same collection by passing different `where` clauses.
+
+```tsx
+// ActiveTodos.tsx
+import { useCollection } from "./useCollection";
+import { todos, type Todo } from "./db";
+
+export function ActiveTodos() {
+  const { docs } = useCollection<Todo>(todos, { completed: false });
+
+  return (
+    <div>
+      <h2>Active ({docs.length})</h2>
+      <ul>
+        {docs.map((todo) => (
+          <li key={todo._id}>{todo.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+```tsx
+// CompletedTodos.tsx
+import { useCollection } from "./useCollection";
+import { todos, type Todo } from "./db";
+
+export function CompletedTodos() {
+  const { docs } = useCollection<Todo>(todos, { completed: true });
+
+  return (
+    <div>
+      <h2>Completed ({docs.length})</h2>
+      <ul>
+        {docs.map((todo) => (
+          <li key={todo._id}>{todo.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+Both components subscribe to the same underlying collection. When a todo is toggled, both views update automatically.
+
+## Watching a single document
+
+For cases where you only care about changes to one specific document, use the `listen` method on the collection.
+
+```tsx
+// TodoDetail.tsx
+import { useState, useEffect } from "react";
+import type { Doc } from "@graphdb/core";
+import { todos, type Todo } from "./db";
+
+export function TodoDetail({ id }: { id: string }) {
+  const [todo, setTodo] = useState<Doc<Todo> | null>(() => todos.read(id));
+
+  useEffect(() => {
+    // Set current value
+    setTodo(todos.read(id));
+
+    // Listen for changes to this specific document
+    const cancel = todos.listen(id, (updatedDoc) => {
+      setTodo(updatedDoc);
+    });
+
+    return () => {
+      cancel();
+    };
+  }, [id]);
+
+  if (!todo) {
+    return <p>Todo not found.</p>;
+  }
+
+  return (
+    <div>
+      <h2>{todo.title}</h2>
+      <p>Status: {todo.completed ? "Done" : "Pending"}</p>
+      <p>Created: {new Date(todo.createdAt).toLocaleString()}</p>
+      <p>Updated: {new Date(todo.updatedAt).toLocaleString()}</p>
+    </div>
+  );
+}
+```
+
+The `listen` callback fires only when the document with the given `id` is updated. The cancel function returned by `listen` is called in the effect cleanup to prevent memory leaks.
+
+## Notes on stability
+
+The `where` and `options` objects passed to `useCollection` are compared by reference. If you create new object literals on every render, the hook will re-subscribe on each render cycle. To avoid this, either define them outside the component or wrap them in `useMemo`.
+
+```tsx
+import { useMemo } from "react";
+
+function FilteredList({ status }: { status: boolean }) {
+  const where = useMemo(() => ({ completed: status }), [status]);
+  const options = useMemo(() => ({ orderBy: { title: "ASC" as const } }), []);
+
+  const { docs } = useCollection<Todo>(todos, where, options);
+
+  return (
+    <ul>
+      {docs.map((todo) => (
+        <li key={todo._id}>{todo.title}</li>
+      ))}
+    </ul>
+  );
+}
+```

--- a/apps/docs/src/content/docs/examples/testing.md
+++ b/apps/docs/src/content/docs/examples/testing.md
@@ -1,0 +1,547 @@
+---
+title: Testing
+description: Testing patterns with Bun test and GraphDB.
+---
+
+GraphDB's synchronous reads and simple factory API make it easy to test. This page shows common testing patterns using Bun's built-in test runner.
+
+## Test helper: fresh database per test
+
+Shared mutable state between tests leads to flaky results. Create a new database and collection for each test.
+
+```typescript
+import { describe, it, expect, beforeEach } from "bun:test";
+import { GraphDB, type Collection, type Doc } from "@graphdb/core";
+
+interface Task {
+  title: string;
+  priority: number;
+  done: boolean;
+}
+
+function createTestCollection() {
+  const db = GraphDB();
+  return db.createCollection<Task>("tasks", {
+    indexes: ["priority", "done"],
+  });
+}
+
+describe("tasks collection", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(() => {
+    tasks = createTestCollection();
+  });
+
+  // tests go here...
+});
+```
+
+Every test starts with an empty collection, so ordering and isolation are guaranteed.
+
+## Testing CRUD operations
+
+### Create and read
+
+```typescript
+describe("create and read", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(() => {
+    tasks = createTestCollection();
+  });
+
+  it("should create a document and return its id", async () => {
+    const id = await tasks.create({
+      title: "Write tests",
+      priority: 1,
+      done: false,
+    });
+
+    expect(id).toBeString();
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("should read back the created document", async () => {
+    const id = await tasks.create({
+      title: "Write tests",
+      priority: 1,
+      done: false,
+    });
+
+    const doc = tasks.read(id);
+
+    expect(doc).not.toBeNull();
+    expect(doc!.title).toBe("Write tests");
+    expect(doc!.priority).toBe(1);
+    expect(doc!.done).toBe(false);
+    expect(doc!._id).toBe(id);
+    expect(doc!.createdAt).toBeNumber();
+    expect(doc!.updatedAt).toBeNumber();
+  });
+
+  it("should return null for a nonexistent id", () => {
+    const doc = tasks.read("does-not-exist");
+    expect(doc).toBeNull();
+  });
+});
+```
+
+### Update
+
+```typescript
+describe("update", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(() => {
+    tasks = createTestCollection();
+  });
+
+  it("should update specific fields and bump updatedAt", async () => {
+    const id = await tasks.create({
+      title: "Original",
+      priority: 3,
+      done: false,
+    });
+
+    const before = tasks.read(id)!;
+    // Small delay so updatedAt differs
+    await new Promise((r) => setTimeout(r, 10));
+
+    const updated = await tasks.update(id, { done: true, priority: 1 });
+
+    expect(updated.done).toBe(true);
+    expect(updated.priority).toBe(1);
+    expect(updated.title).toBe("Original"); // unchanged
+    expect(updated.updatedAt).toBeGreaterThanOrEqual(before.updatedAt);
+  });
+});
+```
+
+### Remove
+
+```typescript
+describe("remove", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(() => {
+    tasks = createTestCollection();
+  });
+
+  it("should remove a document and return acknowledgment", async () => {
+    const id = await tasks.create({
+      title: "To remove",
+      priority: 2,
+      done: false,
+    });
+
+    const result = await tasks.remove(id);
+
+    expect(result.removedId).toBe(id);
+    expect(result.acknowledge).toBe(true);
+    expect(tasks.read(id)).toBeNull();
+  });
+
+  it("should reflect removal in count", async () => {
+    await tasks.create({ title: "A", priority: 1, done: false });
+    const idB = await tasks.create({ title: "B", priority: 2, done: false });
+
+    expect(tasks.count()).toBe(2);
+
+    await tasks.remove(idB);
+
+    expect(tasks.count()).toBe(1);
+  });
+});
+```
+
+## Testing queries
+
+```typescript
+describe("queries", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(async () => {
+    tasks = createTestCollection();
+
+    await tasks.create({ title: "Low priority task", priority: 3, done: false });
+    await tasks.create({ title: "High priority task", priority: 1, done: false });
+    await tasks.create({ title: "Medium done task", priority: 2, done: true });
+    await tasks.create({ title: "High done task", priority: 1, done: true });
+  });
+
+  it("should filter by primitive equality", () => {
+    const results = tasks.query({ done: true });
+    expect(results).toHaveLength(2);
+    results.forEach((doc) => expect(doc.done).toBe(true));
+  });
+
+  it("should filter with comparison operators", () => {
+    const highPriority = tasks.query({ priority: { lte: 1 } });
+    expect(highPriority).toHaveLength(2);
+
+    const lowPriority = tasks.query({ priority: { gt: 2 } });
+    expect(lowPriority).toHaveLength(1);
+    expect(lowPriority[0]!.title).toBe("Low priority task");
+  });
+
+  it("should filter with string operators", () => {
+    const results = tasks.query({ title: { startsWith: "High" } });
+    expect(results).toHaveLength(2);
+  });
+
+  it("should filter with the in operator", () => {
+    const results = tasks.query({ priority: { in: [1, 3] } });
+    expect(results).toHaveLength(3);
+  });
+
+  it("should combine multiple where fields with AND logic", () => {
+    const results = tasks.query({ priority: 1, done: false });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.title).toBe("High priority task");
+  });
+
+  it("should support orderBy, skip, and limit", () => {
+    const page = tasks.query(
+      {},
+      { orderBy: { priority: "ASC" }, skip: 1, limit: 2 },
+    );
+
+    expect(page).toHaveLength(2);
+    // After sorting by priority ASC (1,1,2,3) and skipping 1, we get index 1 and 2
+  });
+
+  it("should return an empty array when nothing matches", () => {
+    const results = tasks.query({ priority: { gt: 100 } });
+    expect(results).toEqual([]);
+  });
+});
+```
+
+## Testing findOne, count, and exists
+
+```typescript
+describe("findOne, count, exists", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(async () => {
+    tasks = createTestCollection();
+    await tasks.create({ title: "Alpha", priority: 1, done: false });
+    await tasks.create({ title: "Beta", priority: 2, done: true });
+  });
+
+  it("findOne should return the first match", () => {
+    const result = tasks.findOne({ done: true });
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Beta");
+  });
+
+  it("findOne should return null when nothing matches", () => {
+    const result = tasks.findOne({ priority: 99 });
+    expect(result).toBeNull();
+  });
+
+  it("count should return total or filtered count", () => {
+    expect(tasks.count()).toBe(2);
+    expect(tasks.count({ done: false })).toBe(1);
+  });
+
+  it("exists should check by id", async () => {
+    const id = await tasks.create({ title: "C", priority: 3, done: false });
+    expect(tasks.exists(id)).toBe(true);
+    expect(tasks.exists("nonexistent")).toBe(false);
+  });
+});
+```
+
+## Testing event listeners
+
+```typescript
+describe("event listeners", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(() => {
+    tasks = createTestCollection();
+  });
+
+  it("should fire create event with the new document", async () => {
+    const events: Doc<Task>[] = [];
+    tasks.on("create", ({ doc }) => events.push(doc));
+
+    await tasks.create({ title: "Test", priority: 1, done: false });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.title).toBe("Test");
+  });
+
+  it("should fire update event with before, after, and patch", async () => {
+    const id = await tasks.create({ title: "Before", priority: 1, done: false });
+
+    let captured: { before: Doc<Task>; after: Doc<Task>; patch: Partial<Task> } | null = null;
+    tasks.on("update", (event) => {
+      captured = event;
+    });
+
+    await tasks.update(id, { title: "After", done: true });
+
+    expect(captured).not.toBeNull();
+    expect(captured!.before.title).toBe("Before");
+    expect(captured!.after.title).toBe("After");
+    expect(captured!.patch).toEqual({ title: "After", done: true });
+  });
+
+  it("should fire remove event with the removed document", async () => {
+    const id = await tasks.create({ title: "Gone", priority: 1, done: false });
+
+    const removed: Doc<Task>[] = [];
+    tasks.on("remove", ({ doc }) => removed.push(doc));
+
+    await tasks.remove(id);
+
+    expect(removed).toHaveLength(1);
+    expect(removed[0]!.title).toBe("Gone");
+  });
+
+  it("should fire populate event with count", async () => {
+    let count = 0;
+    tasks.on("populate", (event) => {
+      count = event.count;
+    });
+
+    await tasks.populate([
+      { title: "A", priority: 1, done: false },
+      { title: "B", priority: 2, done: false },
+      { title: "C", priority: 3, done: true },
+    ]);
+
+    expect(count).toBe(3);
+  });
+
+  it("should stop firing after unsubscribe", async () => {
+    const events: Doc<Task>[] = [];
+    const unsub = tasks.on("create", ({ doc }) => events.push(doc));
+
+    await tasks.create({ title: "First", priority: 1, done: false });
+    unsub();
+    await tasks.create({ title: "Second", priority: 2, done: false });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.title).toBe("First");
+  });
+
+  it("should fire per-document listener on update", async () => {
+    const id = await tasks.create({ title: "Watch me", priority: 1, done: false });
+
+    const snapshots: Doc<Task>[] = [];
+    const cancel = tasks.listen(id, (doc) => snapshots.push(doc));
+
+    await tasks.update(id, { priority: 5 });
+    await tasks.update(id, { done: true });
+
+    cancel();
+    await tasks.update(id, { title: "Ignored" });
+
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0]!.priority).toBe(5);
+    expect(snapshots[1]!.done).toBe(true);
+  });
+});
+```
+
+## Testing syncers
+
+### Successful sync
+
+```typescript
+describe("syncers - success", () => {
+  it("should call the create syncer with the document", async () => {
+    const calls: Doc<Task>[] = [];
+
+    const db = GraphDB();
+    const tasks = db.createCollection<Task>("tasks", {
+      syncers: {
+        create: async (doc) => {
+          calls.push(doc);
+          return true;
+        },
+      },
+    });
+
+    const id = await tasks.create({ title: "Synced", priority: 1, done: false });
+
+    // Allow the syncer to resolve
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!._id).toBe(id);
+    expect(calls[0]!.title).toBe("Synced");
+
+    // Document should still exist since syncer returned true
+    expect(tasks.read(id)).not.toBeNull();
+  });
+});
+```
+
+### Failed sync with revert
+
+```typescript
+describe("syncers - failure and revert", () => {
+  it("should revert a create when syncer returns false", async () => {
+    const db = GraphDB();
+    const tasks = db.createCollection<Task>("tasks", {
+      syncers: {
+        create: async () => false, // reject every create
+      },
+    });
+
+    const errors: Array<{ op: string; docId?: string }> = [];
+    tasks.on("syncError", ({ op, docId }) => {
+      errors.push({ op, docId });
+    });
+
+    const id = await tasks.create({ title: "Will revert", priority: 1, done: false });
+
+    // The document exists optimistically right after create
+    expect(tasks.read(id)).not.toBeNull();
+
+    // Wait for the syncer to run and revert
+    await new Promise((r) => setTimeout(r, 50));
+
+    // After revert, the document should be gone
+    expect(tasks.read(id)).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.op).toBe("create");
+  });
+
+  it("should revert an update when syncer returns false", async () => {
+    const db = GraphDB();
+    const tasks = db.createCollection<Task>("tasks", {
+      syncers: {
+        update: async () => false,
+      },
+    });
+
+    const id = await tasks.create({ title: "Original", priority: 1, done: false });
+
+    await tasks.update(id, { title: "Changed" });
+
+    // Wait for syncer to reject and revert
+    await new Promise((r) => setTimeout(r, 50));
+
+    const doc = tasks.read(id);
+    expect(doc).not.toBeNull();
+    expect(doc!.title).toBe("Original"); // reverted
+  });
+
+  it("should revert a remove when syncer returns false", async () => {
+    const db = GraphDB();
+    const tasks = db.createCollection<Task>("tasks", {
+      syncers: {
+        remove: async () => false,
+      },
+    });
+
+    const id = await tasks.create({ title: "Persistent", priority: 1, done: false });
+
+    await tasks.remove(id);
+
+    // Wait for syncer to reject and revert
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Document should be restored
+    const doc = tasks.read(id);
+    expect(doc).not.toBeNull();
+    expect(doc!.title).toBe("Persistent");
+  });
+});
+```
+
+### Syncer that throws
+
+```typescript
+describe("syncers - exceptions", () => {
+  it("should emit syncError when syncer throws", async () => {
+    const db = GraphDB();
+    const tasks = db.createCollection<Task>("tasks", {
+      syncers: {
+        create: async () => {
+          throw new Error("Network failure");
+        },
+      },
+    });
+
+    const errors: Array<{ op: string; error: unknown }> = [];
+    tasks.on("syncError", ({ op, error }) => {
+      errors.push({ op, error });
+    });
+
+    await tasks.create({ title: "Doomed", priority: 1, done: false });
+
+    // Wait for the syncer to throw and the error event to fire
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.op).toBe("create");
+    expect(errors[0]!.error).toBeInstanceOf(Error);
+  });
+});
+```
+
+## Testing bulk operations
+
+```typescript
+describe("bulk operations", () => {
+  let tasks: Collection<Task>;
+
+  beforeEach(() => {
+    tasks = createTestCollection();
+  });
+
+  it("populate should insert multiple documents", async () => {
+    await tasks.populate([
+      { title: "A", priority: 1, done: false },
+      { title: "B", priority: 2, done: true },
+      { title: "C", priority: 3, done: false },
+    ]);
+
+    expect(tasks.count()).toBe(3);
+  });
+
+  it("updateMany should patch all matching documents", async () => {
+    await tasks.populate([
+      { title: "A", priority: 1, done: false },
+      { title: "B", priority: 2, done: false },
+      { title: "C", priority: 3, done: true },
+    ]);
+
+    await tasks.updateMany({ done: false }, { done: true });
+
+    const allDone = tasks.query({ done: true });
+    expect(allDone).toHaveLength(3);
+  });
+
+  it("removeMany should delete all matching documents", async () => {
+    await tasks.populate([
+      { title: "A", priority: 1, done: false },
+      { title: "B", priority: 2, done: true },
+      { title: "C", priority: 3, done: true },
+    ]);
+
+    await tasks.removeMany({ done: true });
+
+    expect(tasks.count()).toBe(1);
+    expect(tasks.findOne({ title: "A" })).not.toBeNull();
+  });
+
+  it("clear should remove all documents", async () => {
+    await tasks.populate([
+      { title: "A", priority: 1, done: false },
+      { title: "B", priority: 2, done: false },
+    ]);
+
+    await tasks.clear();
+
+    expect(tasks.count()).toBe(0);
+  });
+});
+```

--- a/apps/docs/src/content/docs/getting-started/installation.md
+++ b/apps/docs/src/content/docs/getting-started/installation.md
@@ -1,0 +1,62 @@
+---
+title: Installation
+description: Install GraphDB and start using it in your project.
+---
+
+## Install the package
+
+GraphDB is published as `@graphdb/core` on npm. Install it with your preferred package manager:
+
+```bash
+# Bun (recommended)
+bun add @graphdb/core
+
+# npm
+npm install @graphdb/core
+
+# pnpm
+pnpm add @graphdb/core
+```
+
+The `@graphdb/types` package is included as a dependency of `@graphdb/core` — you don't need to install it separately.
+
+## Import
+
+### ESM (recommended)
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+```
+
+### CommonJS
+
+```javascript
+const { GraphDB } = require('@graphdb/core');
+```
+
+### Type-only imports
+
+If you need just the types (e.g., for interfaces in a separate file):
+
+```typescript
+import type { Doc, Collection, Where, QueryOptions } from '@graphdb/core';
+```
+
+All types from `@graphdb/types` are re-exported from `@graphdb/core`, so you never need to import from `@graphdb/types` directly.
+
+## Compatibility
+
+| Runtime | Minimum Version |
+|---------|----------------|
+| Bun     | 1.x+           |
+| Node.js | 18+            |
+
+GraphDB uses `crypto.randomUUID()` for ID generation, which requires Node.js 18 or later. Bun supports this natively.
+
+## Build formats
+
+GraphDB ships dual CJS/ESM builds with TypeScript declaration files. Your bundler will automatically resolve the correct format.
+
+## Next steps
+
+Head to the [Quick Start](/getting-started/quick-start/) to create your first database and collection.

--- a/apps/docs/src/content/docs/getting-started/migration-v2.md
+++ b/apps/docs/src/content/docs/getting-started/migration-v2.md
@@ -1,0 +1,178 @@
+---
+title: Migration to v2
+description: All breaking changes in GraphDB v2 with before/after code comparisons.
+---
+
+GraphDB v2 is a ground-up rewrite. This guide covers every breaking change with migration examples.
+
+## Timestamp field rename
+
+The `updateAt` field has been renamed to `updatedAt` (with the "d").
+
+```typescript
+// v1
+doc.updateAt; // Date object
+
+// v2
+doc.updatedAt; // number (epoch ms)
+```
+
+## Timestamps are numbers
+
+Timestamps are now epoch milliseconds (`number`), not `Date` objects. This removes the `date-fns` dependency.
+
+```typescript
+// v1
+doc.createdAt; // Date
+doc.updateAt;  // Date
+
+// v2
+doc.createdAt; // 1700000000000
+doc.updatedAt; // 1700000000000
+
+// Convert to Date if needed
+new Date(doc.createdAt);
+```
+
+## query() always returns an array
+
+In v1, `query()` could return a single document or `null`. In v2, it always returns `Doc<T>[]`.
+
+```typescript
+// v1
+const result = col.query({ name: 'Alex' }); // Doc<T> | Doc<T>[] | null
+
+// v2
+const result = col.query({ name: 'Alex' }); // Doc<T>[] (always)
+```
+
+Use the new `findOne()` method to get a single document:
+
+```typescript
+// v2 — get a single document
+const user = col.findOne({ name: 'Alex' }); // Doc<T> | null
+```
+
+## Zero runtime dependencies
+
+GraphDB v2 has no runtime dependencies:
+
+- **Removed `uuid`**: Uses `crypto.randomUUID()` (Node 18+, all Bun versions)
+- **Removed `date-fns`**: Uses `Date.now()` for epoch milliseconds
+
+## Listener payloads changed
+
+Event payloads are now typed objects instead of positional arguments.
+
+```typescript
+// v1
+col.on('create', (doc) => { ... });
+col.on('update', (before, after) => { ... });
+col.on('remove', (doc) => { ... });
+
+// v2
+col.on('create', ({ doc }) => { ... });
+col.on('update', ({ before, after, patch }) => { ... });
+col.on('remove', ({ doc }) => { ... });
+col.on('populate', ({ count }) => { ... });      // new
+col.on('syncError', ({ op, error, docId }) => { ... }); // new
+```
+
+## Skip edge cases fixed
+
+```typescript
+// v1 — skip: 0 might have been treated as falsy
+col.query({}, { skip: 0 }); // inconsistent
+
+// v2 — skip: 0 is valid, returns all results
+col.query({}, { skip: 0 }); // returns all docs
+
+// v2 — skip >= length returns empty array
+col.query({}, { skip: 100 }); // [] (not undefined/error)
+```
+
+## Query pipeline order fixed
+
+The query pipeline is now consistently: **filter -> sort -> skip -> limit**.
+
+```typescript
+// v2 — sort happens before skip/limit
+col.query({}, {
+  orderBy: { age: 'ASC' },
+  skip: 1,
+  limit: 2,
+});
+// Filters first, sorts by age, then skips 1 and takes 2
+```
+
+## Multi-field sort fixed
+
+Multi-field sort now correctly evaluates keys in order. The first non-zero comparison decides the order.
+
+```typescript
+col.query({}, {
+  orderBy: { lastName: 'ASC', age: 'ASC' },
+});
+// Sorts by lastName first, then by age within same lastName
+```
+
+## Top-level RegExp in where clause
+
+RegExp now works at the top level of where clauses:
+
+```typescript
+// v2 — both forms work
+col.query({ name: /^al/i });              // top-level RegExp
+col.query({ name: { match: /^al/i } });   // operator form
+```
+
+## Async/sync error handling
+
+Sync errors are no longer swallowed. Failed syncs properly revert the optimistic write and throw.
+
+```typescript
+// v2 — sync failures throw and revert
+try {
+  await col.create({ name: 'Alex', ... });
+} catch (err) {
+  // Document was NOT persisted (reverted)
+  // syncError event was also emitted
+}
+```
+
+## Populate validates _id
+
+`populate()` now validates that every document has an `_id` field. Duplicates overwrite (last wins).
+
+```typescript
+// v2 — throws if any doc is missing _id
+col.populate([
+  { _id: '1', name: 'Alex', ... }, // ok
+  { name: 'No ID', ... },          // throws!
+]);
+```
+
+## Map/Set for listeners
+
+Listeners use `Map` and `Set` internally for O(1) unsubscribe performance instead of arrays.
+
+```typescript
+// v2 — cancel function removes listener in O(1)
+const cancel = col.on('create', handler);
+cancel(); // O(1) removal, no array splice
+```
+
+## New APIs
+
+These methods are new in v2:
+
+| Method | Description |
+|--------|-------------|
+| `findOne(where)` | Returns `Doc<T> \| null` |
+| `count(where?)` | Returns number of matching documents |
+| `exists(id)` | Returns `boolean` |
+| `clear()` | Removes all documents from collection |
+| `updateMany(where, patch)` | Updates all matching documents |
+| `removeMany(where)` | Removes all matching documents |
+| `on('populate', fn)` | Listen for bulk populate events |
+| `on('syncError', fn)` | Listen for sync errors |

--- a/apps/docs/src/content/docs/getting-started/quick-start.md
+++ b/apps/docs/src/content/docs/getting-started/quick-start.md
@@ -1,0 +1,126 @@
+---
+title: Quick Start
+description: Create your first GraphDB database, add documents, and run queries.
+---
+
+This guide walks you through the core concepts of GraphDB in a few minutes.
+
+## Create a database
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+const db = GraphDB();
+```
+
+`GraphDB()` is a factory function that returns a database instance. It holds a map of named collections.
+
+## Define your model
+
+GraphDB is TypeScript-first. Define your document shape as a plain type:
+
+```typescript
+interface User {
+  name: string;
+  email: string;
+  age: number;
+}
+```
+
+## Create a collection
+
+```typescript
+db.createCollection<User>('users', {
+  indexes: ['email'], // optional: hash index for fast equality lookups
+});
+
+const users = db.getCollection<User>('users')!;
+```
+
+The generic `<User>` parameter gives you full type safety on all operations.
+
+## Create a document
+
+```typescript
+const id = await users.create({
+  name: 'Alex',
+  email: 'alex@example.com',
+  age: 29,
+});
+
+console.log(id); // e.g. "550e8400-e29b-41d4-a716-446655440000"
+```
+
+`create()` is async (to support syncers) and returns the generated `_id`.
+
+## Read a document
+
+```typescript
+const user = users.read(id);
+console.log(user);
+// {
+//   _id: "550e8400-...",
+//   name: "Alex",
+//   email: "alex@example.com",
+//   age: 29,
+//   createdAt: 1700000000000,
+//   updatedAt: 1700000000000
+// }
+```
+
+Every document is wrapped in `Doc<T>`, which adds `_id`, `createdAt`, and `updatedAt` (epoch milliseconds).
+
+## Query documents
+
+```typescript
+// Find all users over 25
+const results = users.query({ age: { gt: 25 } });
+
+// Find one user by email
+const user = users.findOne({ email: 'alex@example.com' });
+```
+
+`query()` always returns `Doc<T>[]` (never null). `findOne()` returns `Doc<T> | null`.
+
+## Update a document
+
+```typescript
+const updated = await users.update(id, { age: 30 });
+console.log(updated.age); // 30
+console.log(updated.updatedAt); // new timestamp
+```
+
+Only the fields you pass in the patch are changed. `updatedAt` is automatically refreshed.
+
+## Remove a document
+
+```typescript
+const result = await users.remove(id);
+console.log(result); // { removedId: "550e8400-...", acknowledge: true }
+```
+
+## Listen to changes
+
+```typescript
+// Collection-level events
+const cancel = users.on('create', ({ doc }) => {
+  console.log('New user:', doc.name);
+});
+
+// Per-document listener
+const cancelDoc = users.listen(id, (payload) => {
+  console.log('Document changed:', payload);
+});
+
+// Unsubscribe
+cancel();
+cancelDoc();
+```
+
+## Next steps
+
+- [CRUD Operations](/guides/crud-operations/) — Full details on create, read, update, and remove
+- [Querying](/guides/querying/) — All where clause operators and query options
+- [Indexes](/guides/indexes/) — When and how to use hash indexes
+- [Listeners & Events](/guides/listeners-events/) — Real-time event system
+- [Syncers](/guides/syncers/) — Backend synchronization

--- a/apps/docs/src/content/docs/guides/bulk-operations.md
+++ b/apps/docs/src/content/docs/guides/bulk-operations.md
@@ -1,0 +1,169 @@
+---
+title: Bulk Operations
+description: Populate, update, and remove documents in bulk.
+---
+
+GraphDB provides several methods for working with documents in bulk: `populate()` for loading data, `updateMany()` and `removeMany()` for batch mutations, and `clear()` for resetting a collection.
+
+## Setup
+
+All examples use the following setup:
+
+```typescript
+import { GraphDB, type Doc } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+const users = db.createCollection<User>('users', {
+  indexes: ['email', 'age'],
+});
+```
+
+## `populate(docs)`
+
+Load an array of pre-existing documents into a collection. This is useful for hydrating the store from an API response, local storage, or a server-side snapshot.
+
+```typescript
+const docs: Doc<User>[] = [
+  { _id: 'u1', name: 'Alice', email: 'alice@example.com', age: 30, createdAt: 1700000000000, updatedAt: 1700000000000 },
+  { _id: 'u2', name: 'Bob', email: 'bob@example.com', age: 25, createdAt: 1700000000000, updatedAt: 1700000000000 },
+  { _id: 'u3', name: 'Carol', email: 'carol@example.com', age: 35, createdAt: 1700000000000, updatedAt: 1700000000000 },
+];
+
+users.populate(docs);
+```
+
+### Validation
+
+Every document passed to `populate()` must have an `_id` field. If any document is missing `_id`, the operation will throw an error.
+
+### Duplicate handling
+
+If multiple documents share the same `_id`, the last one wins. This also applies when populating over existing data: documents with matching IDs are overwritten.
+
+```typescript
+users.populate([
+  { _id: 'u1', name: 'Alice V1', email: 'v1@example.com', age: 30, createdAt: 1700000000000, updatedAt: 1700000000000 },
+  { _id: 'u1', name: 'Alice V2', email: 'v2@example.com', age: 31, createdAt: 1700000000000, updatedAt: 1700000000000 },
+]);
+
+const alice = users.read('u1');
+// alice.name === 'Alice V2'
+```
+
+### Index rebuilding
+
+After population, all indexes defined on the collection are rebuilt to reflect the new data. You do not need to manage indexes manually.
+
+### Populate event
+
+The `populate` event fires once after all documents are loaded, with the count of documents that were populated.
+
+```typescript
+users.on('populate', (payload) => {
+  console.log(`Loaded ${payload.count} users`);
+});
+
+users.populate(docs); // Logs: "Loaded 3 users"
+```
+
+### Typical use case: hydrating from an API
+
+```typescript
+const response = await fetch('/api/users');
+const data: Doc<User>[] = await response.json();
+users.populate(data);
+```
+
+## `updateMany(where, patch)`
+
+Find all documents matching a query and apply a patch to each one. Documents are updated sequentially. Returns an array of the updated documents.
+
+```typescript
+// Give everyone over 30 an age bump
+const updated: Doc<User>[] = await users.updateMany(
+  { age: { gt: 30 } },
+  { age: 36 }
+);
+
+console.log(updated.length); // Number of documents updated
+```
+
+Each update triggers individual `update` events and per-document listeners, and each update goes through the syncer if one is configured.
+
+### Use case: batch status changes
+
+```typescript
+type Task = { title: string; status: string; assignee: string };
+
+const tasks = db.createCollection<Task>('tasks');
+
+// Mark all of Alice's tasks as complete
+await tasks.updateMany(
+  { assignee: 'Alice', status: 'in-progress' },
+  { status: 'complete' }
+);
+```
+
+## `removeMany(where)`
+
+Find all documents matching a query and remove each one sequentially. Returns an array of `RemoveResult` objects.
+
+```typescript
+// Remove all users under 18
+const results: RemoveResult[] = await users.removeMany({ age: { lt: 18 } });
+
+for (const result of results) {
+  console.log(`Removed: ${result.removedId}, acknowledged: ${result.acknowledge}`);
+}
+```
+
+Each removal triggers individual `remove` events and per-document listeners, and each removal goes through the syncer if one is configured.
+
+### Use case: cleanup expired records
+
+```typescript
+type Session = { userId: string; expiresAt: number };
+
+const sessions = db.createCollection<Session>('sessions');
+
+const now = Date.now();
+await sessions.removeMany({ expiresAt: { lt: now } });
+```
+
+## `clear()`
+
+Remove all documents from the collection and reset all indexes. No events are emitted.
+
+```typescript
+users.clear();
+
+console.log(users.count()); // 0
+```
+
+### Use case: resetting state
+
+`clear()` is useful for tests, logout flows, or any scenario where you need to start fresh without destroying and recreating the collection.
+
+```typescript
+// In a test
+beforeEach(() => {
+  users.clear();
+});
+
+// On logout
+function logout() {
+  users.clear();
+  sessions.clear();
+}
+```
+
+## Summary
+
+| Method       | Returns           | Emits events | Goes through syncers |
+| ------------ | ----------------- | ------------ | -------------------- |
+| `populate`   | `void`            | `populate`   | No                   |
+| `updateMany` | `Doc<T>[]`        | `update` per doc | Yes              |
+| `removeMany` | `RemoveResult[]`  | `remove` per doc | Yes              |
+| `clear`      | `void`            | None         | No                   |

--- a/apps/docs/src/content/docs/guides/crud-operations.md
+++ b/apps/docs/src/content/docs/guides/crud-operations.md
@@ -1,0 +1,196 @@
+---
+title: CRUD Operations
+description: Create, read, update, and remove documents in GraphDB.
+---
+
+GraphDB provides a straightforward API for managing documents. Read operations are **synchronous** while write operations (create, update, remove) are **asynchronous** to support syncer integration.
+
+All examples below use this setup:
+
+```ts
+import { GraphDB } from "@graphdb/core";
+
+type User = {
+  name: string;
+  email: string;
+  age: number;
+};
+
+const db = GraphDB();
+const users = db.createCollection<User>("users");
+```
+
+## Create
+
+`create()` is async. It generates a unique `_id` via `crypto.randomUUID()`, sets `createdAt` and `updatedAt` timestamps (epoch milliseconds), and returns the new document's ID.
+
+```ts
+const id = await users.create({
+  name: "Alex",
+  email: "alex@example.com",
+  age: 30,
+});
+
+console.log(id); // "a1b2c3d4-..."
+```
+
+The stored document has the shape `Doc<User>`:
+
+```ts
+{
+  _id: "a1b2c3d4-...",
+  createdAt: 1708099200000,
+  updatedAt: 1708099200000,
+  name: "Alex",
+  email: "alex@example.com",
+  age: 30,
+}
+```
+
+If a syncer is configured with a `create` function, GraphDB writes the document optimistically and then calls the syncer. If the syncer returns `false` or throws, the document is automatically reverted (removed) and a `syncError` event is emitted.
+
+## Read
+
+`read()` is **synchronous**. It takes a document ID and returns `Doc<User> | null`.
+
+```ts
+const user = users.read(id);
+
+if (user) {
+  console.log(user.name); // "Alex"
+  console.log(user._id); // "a1b2c3d4-..."
+  console.log(user.createdAt); // 1708099200000
+}
+```
+
+If no document exists with the given ID, `read()` returns `null`:
+
+```ts
+const missing = users.read("nonexistent-id");
+console.log(missing); // null
+```
+
+## Update
+
+`update()` is async. It takes a document ID and a partial patch object. Only the fields you provide are updated; the rest remain unchanged. The `updatedAt` timestamp is refreshed automatically. It returns the full updated `Doc<User>`.
+
+```ts
+const updated = await users.update(id, { age: 31 });
+
+console.log(updated.age); // 31
+console.log(updated.name); // "Alex" (unchanged)
+console.log(updated.updatedAt); // new timestamp, greater than createdAt
+```
+
+### Error cases
+
+Calling `update()` without an ID throws:
+
+```ts
+await users.update("", { age: 31 });
+// Error: "You must provide the GraphDocument ID that you would like to update."
+```
+
+Updating a document that does not exist throws:
+
+```ts
+await users.update("nonexistent-id", { age: 31 });
+// Error: "No document to update found with ID: nonexistent-id"
+```
+
+### Syncer interaction
+
+If a syncer is configured with an `update` function, GraphDB applies the patch optimistically and then calls the syncer. If the syncer fails, the document is automatically reverted to its previous state and a `syncError` event is emitted.
+
+## Remove
+
+`remove()` is async. It takes a document ID and returns a `RemoveResult` object.
+
+```ts
+const result = await users.remove(id);
+
+console.log(result);
+// { removedId: "a1b2c3d4-...", acknowledge: true }
+```
+
+### Error cases
+
+Calling `remove()` without an ID throws:
+
+```ts
+await users.remove("");
+// Error: "You must provide the GraphDocument ID that you would like to remove."
+```
+
+Removing a document that does not exist throws:
+
+```ts
+await users.remove("nonexistent-id");
+// Error: "No document to remove found with ID: nonexistent-id"
+```
+
+### Syncer interaction
+
+If a syncer is configured with a `remove` function, GraphDB removes the document optimistically and then calls the syncer. If the syncer fails, the document is automatically restored and a `syncError` event is emitted.
+
+## Bulk operations
+
+### updateMany
+
+Update all documents matching a where clause with the same patch:
+
+```ts
+await users.updateMany({ age: { gte: 30 } }, { name: "Senior" });
+```
+
+### removeMany
+
+Remove all documents matching a where clause:
+
+```ts
+await users.removeMany({ age: { lt: 18 } });
+```
+
+### populate
+
+Load an array of existing documents into the collection. Every document **must** have an `_id` field.
+
+```ts
+users.populate([
+  { _id: "user-1", createdAt: Date.now(), updatedAt: Date.now(), name: "Alex", email: "alex@example.com", age: 30 },
+  { _id: "user-2", createdAt: Date.now(), updatedAt: Date.now(), name: "Sam", email: "sam@example.com", age: 25 },
+]);
+```
+
+If any document is missing an `_id`, it throws:
+
+```ts
+// Error: "Every document must have an _id for populate."
+```
+
+## Utility methods
+
+### count
+
+Count documents, optionally filtered by a where clause:
+
+```ts
+const total = users.count();
+const adults = users.count({ age: { gte: 18 } });
+```
+
+### exists
+
+Check if a document exists by ID:
+
+```ts
+const found = users.exists(id); // true or false
+```
+
+### clear
+
+Remove all documents from the collection:
+
+```ts
+users.clear();
+```

--- a/apps/docs/src/content/docs/guides/indexes.md
+++ b/apps/docs/src/content/docs/guides/indexes.md
@@ -1,0 +1,131 @@
+---
+title: Indexes
+description: Use hash indexes to accelerate equality lookups.
+---
+
+GraphDB supports hash indexes on specified fields to speed up queries that use equality-based lookups. Indexes trade memory for query performance -- they are most valuable on fields you frequently filter by.
+
+## Configuring indexes
+
+Pass an `indexes` array when creating a collection:
+
+```ts
+import { GraphDB } from "@graphdb/core";
+
+type User = {
+  name: string;
+  email: string;
+  age: number;
+};
+
+const db = GraphDB();
+const users = db.createCollection<User>("users", {
+  indexes: ["email", "age"],
+});
+```
+
+Each indexed field gets a hash map data structure that maps field values to sets of document IDs.
+
+## Which operators benefit from indexes
+
+Indexes accelerate these lookup types:
+
+| Lookup type | Example | Uses index |
+|---|---|---|
+| Primitive equality | `{ email: "alex@example.com" }` | Yes |
+| `eq` operator | `{ email: { eq: "alex@example.com" } }` | Yes |
+| `in` operator | `{ age: { in: [25, 30, 35] } }` | Yes |
+
+For `in` queries, GraphDB looks up each value in the index and unions the resulting document ID sets, avoiding a full collection scan.
+
+## Which operators do NOT use indexes
+
+These operators always require scanning documents (either the full collection or a candidate set):
+
+| Operator | Example |
+|---|---|
+| `notEq` | `{ age: { notEq: 30 } }` |
+| `gt` | `{ age: { gt: 25 } }` |
+| `gte` | `{ age: { gte: 25 } }` |
+| `lt` | `{ age: { lt: 30 } }` |
+| `lte` | `{ age: { lte: 30 } }` |
+| `includes` | `{ email: { includes: "example" } }` |
+| `startsWith` | `{ name: { startsWith: "Al" } }` |
+| `endsWith` | `{ email: { endsWith: ".com" } }` |
+| `match` (RegExp) | `{ name: { match: /alex/i } }` |
+| Top-level RegExp | `{ name: /alex/i }` |
+
+When a query combines an indexed field (with an equality or `in` check) and a non-indexed operator, GraphDB uses the index to narrow the candidate set first, then applies the remaining filters via scan on those candidates.
+
+## Internal structure
+
+Indexes use a nested `Map` structure:
+
+```
+Map<field, Map<value, Set<docId>>>
+```
+
+For example, with an index on `age`:
+
+```
+"age" -> Map {
+  25 -> Set { "id-sam" },
+  30 -> Set { "id-alex" },
+  35 -> Set { "id-jordan" },
+}
+```
+
+Looking up `{ age: 30 }` is an O(1) map lookup to retrieve the set of matching document IDs, compared to scanning every document in the collection.
+
+## Index maintenance
+
+Indexes are automatically kept in sync with the collection data:
+
+- **create** -- the new document's indexed field values are added to the index.
+- **update** -- the old values are removed from the index and the new values are added.
+- **remove** -- the document's indexed field values are removed from the index.
+- **populate** -- indexes are rebuilt for all populated documents.
+- **clear** -- indexes are cleared along with the collection data.
+
+You never need to manually rebuild or refresh indexes.
+
+## Index-assisted queries vs full scans
+
+Consider a collection with 10,000 users and an index on `email`:
+
+```ts
+// Index-assisted: O(1) lookup
+users.query({ email: { eq: "alex@example.com" } });
+
+// Full scan: checks all 10,000 documents
+users.query({ age: { gt: 25 } });
+```
+
+When mixing indexed and non-indexed fields:
+
+```ts
+// Index narrows candidates first, then scans only those
+users.query({
+  email: { eq: "alex@example.com" },
+  age: { gt: 25 },
+});
+```
+
+Here, the index on `email` produces a small candidate set (likely one document), and the `age` filter is applied only to that candidate -- not to the full collection.
+
+## Trade-offs
+
+**Benefits:**
+- Equality and `in` lookups become O(1) instead of O(n).
+- Queries combining indexed and non-indexed fields scan fewer documents.
+
+**Costs:**
+- Each index adds memory proportional to the number of unique values in the field.
+- Every write operation (create, update, remove) must also update the index, adding a small overhead.
+
+## Best practices
+
+- Index fields you frequently query with equality checks or `in` operators.
+- Avoid indexing fields with extremely high cardinality where every value is unique (like `_id`) unless you need fast equality lookups on them.
+- Avoid indexing fields you rarely query -- the write overhead is not worth it.
+- Fields used primarily with range operators (`gt`, `lt`, `gte`, `lte`) or string matching (`includes`, `startsWith`, `endsWith`, `match`) do not benefit from hash indexes.

--- a/apps/docs/src/content/docs/guides/listeners-events.md
+++ b/apps/docs/src/content/docs/guides/listeners-events.md
@@ -1,0 +1,154 @@
+---
+title: Listeners & Events
+description: React to document changes with collection events and per-document listeners.
+---
+
+GraphDB provides two mechanisms for reacting to data changes: **collection-level events** via `on()` and **per-document listeners** via `listen()`. Both return a `CancelFn` for cleanup, and both use `Map`/`Set` internally for O(1) unsubscribe performance.
+
+## Collection-level events with `on()`
+
+The `on()` method subscribes to events across the entire collection. It returns a `CancelFn` that removes the listener when called.
+
+```typescript
+import { GraphDB } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const db = GraphDB();
+const users = db.createCollection<User>('users');
+
+const cancel = users.on('create', (payload) => {
+  console.log('New user created:', payload.doc.name);
+});
+
+// Later, stop listening
+cancel();
+```
+
+### Event types and payloads
+
+There are five event types, each with a typed payload.
+
+#### `create` — fires after a document is created
+
+```typescript
+users.on('create', (payload: CreatePayload<User>) => {
+  // payload.doc — the full Doc<User> that was created
+  console.log(payload.doc._id, payload.doc.name);
+});
+```
+
+#### `update` — fires after a document is updated
+
+```typescript
+users.on('update', (payload: UpdatePayload<User>) => {
+  // payload.before — Doc<User> before the update
+  // payload.after  — Doc<User> after the update
+  // payload.patch  — the partial object that was applied
+  console.log('Changed:', Object.keys(payload.patch));
+});
+```
+
+#### `remove` — fires after a document is removed
+
+```typescript
+users.on('remove', (payload: RemovePayload<User>) => {
+  // payload.doc — the Doc<User> that was removed
+  console.log('Removed user:', payload.doc.email);
+});
+```
+
+#### `populate` — fires after bulk population
+
+```typescript
+users.on('populate', (payload: PopulatePayload) => {
+  // payload.count — number of documents that were populated
+  console.log(`Loaded ${payload.count} users`);
+});
+```
+
+#### `syncError` — fires when a syncer operation fails
+
+```typescript
+users.on('syncError', (payload: SyncErrorPayload) => {
+  // payload.op    — 'create' | 'update' | 'remove'
+  // payload.error — the error that was thrown or caught
+  // payload.docId — the document ID (when available)
+  console.error(`Sync failed for ${payload.op}:`, payload.error);
+});
+```
+
+### Multiple listeners on the same event
+
+You can register as many listeners as you need for any event. Each call to `on()` returns its own independent `CancelFn`.
+
+```typescript
+const cancelLog = users.on('create', (payload) => {
+  console.log('Log:', payload.doc.name);
+});
+
+const cancelAnalytics = users.on('create', (payload) => {
+  trackEvent('user_created', { id: payload.doc._id });
+});
+
+// Remove only the analytics listener
+cancelAnalytics();
+// The log listener continues to fire
+```
+
+## Per-document listeners with `listen()`
+
+The `listen()` method subscribes to changes for a single document by its `_id`. The handler fires on create, update, or remove operations that affect that specific document.
+
+```typescript
+const doc = await users.create({ name: 'Alice', email: 'alice@example.com', age: 30 });
+
+const cancel = users.listen(doc._id, (payload: ListenerPayload<User>) => {
+  console.log('Document changed:', payload);
+});
+
+// This triggers the listener
+await users.update(doc._id, { age: 31 });
+
+// This also triggers it
+await users.remove(doc._id);
+
+// Stop listening
+cancel();
+```
+
+The `ListenerPayload<T>` is a union of `CreatePayload<T>`, `UpdatePayload<T>`, and `RemovePayload<T>`. You can distinguish between them by checking which properties exist on the payload.
+
+```typescript
+users.listen(doc._id, (payload) => {
+  if ('before' in payload) {
+    // UpdatePayload — has before, after, patch
+    console.log('Updated from', payload.before.age, 'to', payload.after.age);
+  } else if ('doc' in payload) {
+    // Could be CreatePayload or RemovePayload
+    console.log('Created or removed:', payload.doc._id);
+  }
+});
+```
+
+## Cleanup patterns
+
+Always store cancel functions and call them when listeners are no longer needed to avoid memory leaks.
+
+```typescript
+// Store all cancel functions for batch cleanup
+const cancellers: CancelFn[] = [];
+
+cancellers.push(users.on('create', handleCreate));
+cancellers.push(users.on('update', handleUpdate));
+cancellers.push(users.on('remove', handleRemove));
+cancellers.push(users.listen(someDocId, handleDocChange));
+
+// Clean up all listeners at once
+function teardown() {
+  cancellers.forEach((cancel) => cancel());
+  cancellers.length = 0;
+}
+```
+
+Calling a `CancelFn` more than once is safe and has no effect after the first call.

--- a/apps/docs/src/content/docs/guides/querying.md
+++ b/apps/docs/src/content/docs/guides/querying.md
@@ -1,0 +1,210 @@
+---
+title: Querying
+description: Query documents with where clauses, operators, and options.
+---
+
+GraphDB provides two synchronous methods for querying documents: `query()` which returns an array of matching documents, and `findOne()` which returns the first match or `null`.
+
+All examples below use this setup:
+
+```ts
+import { GraphDB } from "@graphdb/core";
+
+type User = {
+  name: string;
+  email: string;
+  age: number;
+};
+
+const db = GraphDB();
+const users = db.createCollection<User>("users");
+
+await users.create({ name: "Alex", email: "alex@example.com", age: 30 });
+await users.create({ name: "Sam", email: "sam@example.com", age: 25 });
+await users.create({ name: "Jordan", email: "jordan@example.com", age: 35 });
+```
+
+## query()
+
+`query()` is synchronous and always returns `Doc<User>[]` -- never `null`. If nothing matches, it returns an empty array.
+
+```ts
+const results = users.query({ age: { gte: 30 } });
+// [Doc<User>, Doc<User>] -- Alex and Jordan
+```
+
+Pass an empty object to get all documents:
+
+```ts
+const all = users.query({});
+```
+
+## findOne()
+
+`findOne()` is synchronous and returns `Doc<User> | null`. It returns the first document that matches the where clause.
+
+```ts
+const user = users.findOne({ name: "Alex" });
+// Doc<User> | null
+```
+
+## Primitive equality
+
+The simplest form of a where clause uses direct value matching:
+
+```ts
+const results = users.query({ name: "Alex" });
+```
+
+This matches documents where `name` is exactly `"Alex"`.
+
+## RegExp matching
+
+You can use a RegExp directly at the top level of a where clause:
+
+```ts
+const results = users.query({ name: /alex/i });
+```
+
+Or use the `match` operator for the same effect:
+
+```ts
+const results = users.query({ name: { match: /alex/i } });
+```
+
+## Operators
+
+### eq
+
+Strict equality check:
+
+```ts
+users.query({ age: { eq: 30 } });
+```
+
+### notEq
+
+Not equal:
+
+```ts
+users.query({ age: { notEq: 30 } });
+// Sam (25) and Jordan (35)
+```
+
+### gt
+
+Greater than:
+
+```ts
+users.query({ age: { gt: 25 } });
+// Alex (30) and Jordan (35)
+```
+
+### gte
+
+Greater than or equal:
+
+```ts
+users.query({ age: { gte: 30 } });
+// Alex (30) and Jordan (35)
+```
+
+### lt
+
+Less than:
+
+```ts
+users.query({ age: { lt: 30 } });
+// Sam (25)
+```
+
+### lte
+
+Less than or equal:
+
+```ts
+users.query({ age: { lte: 30 } });
+// Sam (25) and Alex (30)
+```
+
+### includes
+
+Check if a string field contains a substring:
+
+```ts
+users.query({ email: { includes: "example" } });
+// All users
+```
+
+### startsWith
+
+Check if a string field starts with a prefix:
+
+```ts
+users.query({ name: { startsWith: "Al" } });
+// Alex
+```
+
+### endsWith
+
+Check if a string field ends with a suffix:
+
+```ts
+users.query({ email: { endsWith: ".com" } });
+// All users
+```
+
+### match
+
+Match against a regular expression:
+
+```ts
+users.query({ name: { match: /^[AJ]/ } });
+// Alex and Jordan
+```
+
+### in
+
+Match any value in an array:
+
+```ts
+users.query({ age: { in: [25, 35] } });
+// Sam (25) and Jordan (35)
+```
+
+## Multi-field where clauses
+
+You can combine multiple fields in a single where clause. A document must match **all** conditions:
+
+```ts
+const results = users.query({
+  age: { gte: 25 },
+  name: { startsWith: "A" },
+});
+// Only Alex matches both conditions
+```
+
+## Query options
+
+The second argument to `query()` is an optional `QueryOptions` object with `orderBy`, `skip`, and `limit`.
+
+```ts
+const results = users.query({ age: { gte: 20 } }, {
+  orderBy: { age: "DESC" },
+  skip: 0,
+  limit: 2,
+});
+```
+
+See the [Sorting & Pagination](/guides/sorting-pagination) guide for full details on these options.
+
+## Pipeline order
+
+Queries execute in a fixed order:
+
+1. **Filter** -- apply the where clause to select matching documents
+2. **Sort** -- order the results by `orderBy` fields
+3. **Skip** -- skip the first N results
+4. **Limit** -- take at most N results from what remains
+
+This means sorting happens on the full filtered set before pagination is applied, giving you predictable paginated results.

--- a/apps/docs/src/content/docs/guides/sorting-pagination.md
+++ b/apps/docs/src/content/docs/guides/sorting-pagination.md
@@ -1,0 +1,181 @@
+---
+title: Sorting & Pagination
+description: Sort results and paginate with skip and limit.
+---
+
+GraphDB supports sorting and pagination through the `QueryOptions` parameter on `query()`. The pipeline always executes in the order: **filter, sort, skip, limit**.
+
+All examples below use this setup:
+
+```ts
+import { GraphDB } from "@graphdb/core";
+
+type User = {
+  name: string;
+  email: string;
+  age: number;
+};
+
+const db = GraphDB();
+const users = db.createCollection<User>("users");
+
+await users.create({ name: "Alex", email: "alex@example.com", age: 30 });
+await users.create({ name: "Sam", email: "sam@example.com", age: 25 });
+await users.create({ name: "Jordan", email: "jordan@example.com", age: 35 });
+await users.create({ name: "Alex", email: "alex2@example.com", age: 22 });
+```
+
+## Sorting with orderBy
+
+Use `orderBy` to sort results by one or more fields. Each field can be sorted in `"ASC"` (ascending) or `"DESC"` (descending) order.
+
+### Single-field sort
+
+```ts
+const youngest = users.query({}, {
+  orderBy: { age: "ASC" },
+});
+// Alex (22), Sam (25), Alex (30), Jordan (35)
+
+const oldest = users.query({}, {
+  orderBy: { age: "DESC" },
+});
+// Jordan (35), Alex (30), Sam (25), Alex (22)
+```
+
+### Multi-field sort
+
+When sorting by multiple fields, the first field is compared first. If two documents have the same value for the first field, the second field is used as a tiebreaker, and so on.
+
+```ts
+const sorted = users.query({}, {
+  orderBy: { name: "ASC", age: "DESC" },
+});
+// Alex (30), Alex (22), Jordan (35), Sam (25)
+// Both "Alex" entries are grouped, with age descending within that group
+```
+
+### Sort behavior by type
+
+- **Strings** are compared using `localeCompare()`, which provides locale-aware alphabetical ordering.
+- **Numbers** are compared using subtraction (`a - b`), giving standard numerical ordering.
+- **Unsupported types** (objects, booleans, etc.) are treated as equal, preserving their original order relative to each other.
+
+## Pagination with skip and limit
+
+### skip
+
+`skip` specifies how many documents to skip from the beginning of the sorted results.
+
+```ts
+const results = users.query({}, {
+  orderBy: { age: "ASC" },
+  skip: 1,
+});
+// Sam (25), Alex (30), Jordan (35) -- skipped Alex (22)
+```
+
+A `skip` of `0` has no effect:
+
+```ts
+const results = users.query({}, { skip: 0 });
+// All documents returned
+```
+
+If `skip` is greater than or equal to the number of results, an empty array is returned:
+
+```ts
+const results = users.query({}, { skip: 100 });
+// []
+```
+
+### limit
+
+`limit` specifies the maximum number of documents to return.
+
+```ts
+const results = users.query({}, {
+  orderBy: { age: "ASC" },
+  limit: 2,
+});
+// Alex (22), Sam (25)
+```
+
+A `limit` of `0` returns an empty array:
+
+```ts
+const results = users.query({}, { limit: 0 });
+// []
+```
+
+### Combining skip and limit
+
+Use both together for page-based pagination:
+
+```ts
+const pageSize = 2;
+
+// Page 1
+const page1 = users.query({}, {
+  orderBy: { age: "ASC" },
+  skip: 0,
+  limit: pageSize,
+});
+// Alex (22), Sam (25)
+
+// Page 2
+const page2 = users.query({}, {
+  orderBy: { age: "ASC" },
+  skip: 2,
+  limit: pageSize,
+});
+// Alex (30), Jordan (35)
+
+// Page 3 (beyond data)
+const page3 = users.query({}, {
+  orderBy: { age: "ASC" },
+  skip: 4,
+  limit: pageSize,
+});
+// []
+```
+
+## Pipeline order
+
+The query pipeline always runs in this fixed order:
+
+1. **Filter** -- select documents matching the where clause
+2. **Sort** -- order the filtered results by `orderBy`
+3. **Skip** -- discard the first N documents
+4. **Limit** -- take at most N documents from what remains
+
+This order matters. Sorting is applied to the full filtered set before pagination, so you always get a consistent page of results regardless of insertion order.
+
+```ts
+// Get the 2nd and 3rd oldest users who are at least 25
+const results = users.query({ age: { gte: 25 } }, {
+  orderBy: { age: "DESC" },
+  skip: 1,
+  limit: 2,
+});
+// Filter: Alex (30), Sam (25), Jordan (35)
+// Sort (DESC): Jordan (35), Alex (30), Sam (25)
+// Skip 1: Alex (30), Sam (25)
+// Limit 2: Alex (30), Sam (25)
+```
+
+## Using with count
+
+Combine `count()` with pagination to know the total number of matching documents:
+
+```ts
+const where = { age: { gte: 25 } };
+const total = users.count(where);
+const page = users.query(where, {
+  orderBy: { age: "ASC" },
+  skip: 0,
+  limit: 10,
+});
+
+console.log(`Showing ${page.length} of ${total} results`);
+```

--- a/apps/docs/src/content/docs/guides/syncers.md
+++ b/apps/docs/src/content/docs/guides/syncers.md
@@ -1,0 +1,188 @@
+---
+title: Syncers
+description: Synchronize your in-memory data with a backend API.
+---
+
+Syncers let you bridge GraphDB's in-memory store with an external backend. When configured, every `create`, `update`, or `remove` operation will first apply the change optimistically, then call your syncer function. If the syncer fails, GraphDB automatically reverts the change.
+
+## Configuring syncers
+
+Pass a `syncers` object when creating a collection. Each syncer is an async function that returns a `boolean`.
+
+```typescript
+import { GraphDB, type Syncers } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const syncers: Syncers<User> = {
+  create: async (doc) => { /* ... */ return true; },
+  update: async (doc) => { /* ... */ return true; },
+  remove: async (docId) => { /* ... */ return true; },
+};
+
+const db = GraphDB();
+const users = db.createCollection<User>('users', { syncers });
+```
+
+### Syncer signatures
+
+| Syncer   | Argument       | Return    |
+| -------- | -------------- | --------- |
+| `create` | `Doc<User>`    | `boolean` |
+| `update` | `Doc<User>`    | `boolean` |
+| `remove` | `string` (id)  | `boolean` |
+
+- **`create`** receives the full document (including `_id`, `createdAt`, `updatedAt`) after it has been written to memory.
+- **`update`** receives the full document after the patch has been applied.
+- **`remove`** receives just the document ID as a string.
+
+### Partial configuration
+
+You do not have to provide all three syncers. Only the operations you define will be synced; the others work as normal in-memory operations.
+
+```typescript
+const users = db.createCollection<User>('users', {
+  syncers: {
+    create: async (doc) => {
+      // Only sync creates to the backend
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        body: JSON.stringify(doc),
+      });
+      return res.ok;
+    },
+    // update and remove are local-only
+  },
+});
+```
+
+## Optimistic write flow
+
+Every synced operation follows the same pattern:
+
+1. **Apply** the change to the in-memory store immediately.
+2. **Call** the corresponding syncer function.
+3. **On success** (returns `true`): the change persists, events fire normally.
+4. **On failure** (returns `false` or throws): **revert** the in-memory change and throw an error.
+
+This means your UI can react to changes instantly while the backend sync happens in the background.
+
+### Returning `false` vs throwing
+
+Both cause the same revert behavior, but they differ in the error that propagates:
+
+- **Returning `false`**: GraphDB throws a generic sync failure error.
+- **Throwing an error**: GraphDB catches it, reverts, and re-throws the original error so you can inspect it.
+
+```typescript
+const syncers: Syncers<User> = {
+  create: async (doc) => {
+    const res = await fetch('/api/users', {
+      method: 'POST',
+      body: JSON.stringify(doc),
+    });
+
+    if (!res.ok) {
+      // Option A: return false — generic error is thrown
+      return false;
+
+      // Option B: throw — your error is re-thrown
+      // throw new Error(`API returned ${res.status}`);
+    }
+
+    return true;
+  },
+};
+```
+
+## The `syncError` event
+
+When a syncer fails, GraphDB emits a `syncError` event on the collection in addition to throwing. This is useful for centralized error handling or logging.
+
+```typescript
+users.on('syncError', (payload) => {
+  // payload.op    — 'create' | 'update' | 'remove'
+  // payload.error — the caught error
+  // payload.docId — the document ID (when available)
+  console.error(`Sync ${payload.op} failed:`, payload.error);
+});
+```
+
+## Practical example: REST API
+
+Here is a complete example that syncs a users collection with a REST API.
+
+```typescript
+import { GraphDB, type Doc } from '@graphdb/core';
+
+type User = { name: string; email: string; age: number };
+
+const API = 'https://api.example.com/users';
+
+const db = GraphDB();
+
+const users = db.createCollection<User>('users', {
+  syncers: {
+    create: async (doc: Doc<User>) => {
+      const res = await fetch(API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(doc),
+      });
+      if (!res.ok) throw new Error(`Create failed: ${res.status}`);
+      return true;
+    },
+
+    update: async (doc: Doc<User>) => {
+      const res = await fetch(`${API}/${doc._id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(doc),
+      });
+      if (!res.ok) throw new Error(`Update failed: ${res.status}`);
+      return true;
+    },
+
+    remove: async (docId: string) => {
+      const res = await fetch(`${API}/${docId}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) throw new Error(`Remove failed: ${res.status}`);
+      return true;
+    },
+  },
+});
+
+// Centralized error handling
+users.on('syncError', ({ op, error, docId }) => {
+  reportToErrorTracker({ op, error, docId });
+});
+```
+
+## Error handling patterns
+
+### Try/catch per operation
+
+```typescript
+try {
+  const user = await users.create({
+    name: 'Alice',
+    email: 'alice@example.com',
+    age: 30,
+  });
+  console.log('User created and synced:', user._id);
+} catch (err) {
+  // The create was reverted in memory
+  console.error('Failed to sync user creation:', err);
+}
+```
+
+### Global error listener
+
+```typescript
+users.on('syncError', ({ op, error, docId }) => {
+  showToast(`Failed to ${op} document. Please try again.`);
+});
+```
+
+Both patterns can be used together. The `syncError` event always fires on failure regardless of whether the caller catches the thrown error.

--- a/apps/docs/src/content/docs/guides/typescript-types.md
+++ b/apps/docs/src/content/docs/guides/typescript-types.md
@@ -1,0 +1,362 @@
+---
+title: TypeScript Types
+description: All TypeScript types exported by GraphDB.
+---
+
+GraphDB is written in TypeScript and exports all of its types for use in your application. Types are defined in the `@graphdb/types` package and re-exported from `@graphdb/core`, so you can import everything from a single package.
+
+```typescript
+import { GraphDB, type Doc, type Where, type Collection } from '@graphdb/core';
+```
+
+## Type definitions
+
+All examples reference this base type:
+
+```typescript
+type User = { name: string; email: string; age: number };
+```
+
+---
+
+### `Doc<T>`
+
+A stored document. Wraps your data type `T` with metadata fields added by GraphDB.
+
+```typescript
+type Doc<T> = { _id: string; createdAt: number; updatedAt: number } & T;
+```
+
+- `_id` — Unique identifier, generated via `crypto.randomUUID()`.
+- `createdAt` — Epoch milliseconds when the document was created.
+- `updatedAt` — Epoch milliseconds when the document was last updated.
+
+```typescript
+const user: Doc<User> = {
+  _id: '550e8400-e29b-41d4-a716-446655440000',
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+  name: 'Alice',
+  email: 'alice@example.com',
+  age: 30,
+};
+```
+
+---
+
+### `Where<T>`
+
+A filter object used by `query()`, `findOne()`, `updateMany()`, and `removeMany()`. Each key maps to a field on `T` and accepts a direct value, a `WhereClause`, or a `RegExp`.
+
+```typescript
+type Where<T> = {
+  [K in keyof T]?: T[K] | WhereClause<T[K]> | RegExp;
+} & Record<string, unknown>;
+```
+
+```typescript
+// Direct value match
+const byName: Where<User> = { name: 'Alice' };
+
+// Operator-based match
+const olderThan25: Where<User> = { age: { gt: 25 } };
+
+// RegExp match
+const gmailUsers: Where<User> = { email: /gmail\.com$/ };
+```
+
+---
+
+### `WhereClause<V>`
+
+Operator object for fine-grained filtering on a single field.
+
+```typescript
+type WhereClause<V> = {
+  eq?: V;
+  notEq?: V;
+  gt?: number;
+  gte?: number;
+  lt?: number;
+  lte?: number;
+  includes?: string;
+  startsWith?: string;
+  endsWith?: string;
+  match?: RegExp;
+  in?: V[];
+};
+```
+
+| Operator     | Description                        | Applicable types   |
+| ------------ | ---------------------------------- | ------------------ |
+| `eq`         | Equal to                           | Any                |
+| `notEq`      | Not equal to                       | Any                |
+| `gt`         | Greater than                       | `number`           |
+| `gte`        | Greater than or equal              | `number`           |
+| `lt`         | Less than                          | `number`           |
+| `lte`        | Less than or equal                 | `number`           |
+| `includes`   | String contains substring          | `string`           |
+| `startsWith` | String starts with                 | `string`           |
+| `endsWith`   | String ends with                   | `string`           |
+| `match`      | Matches a regular expression       | `string`           |
+| `in`         | Value is in the provided array     | Any                |
+
+```typescript
+// Users aged 25-35 whose email contains "example"
+const results = users.query({
+  age: { gte: 25, lte: 35 },
+  email: { includes: 'example' },
+});
+```
+
+---
+
+### `QueryOptions`
+
+Options for pagination and sorting in `query()`.
+
+```typescript
+type QueryOptions = {
+  skip?: number;
+  limit?: number;
+  orderBy?: Record<string, 'ASC' | 'DESC'>;
+};
+```
+
+```typescript
+// Get the 10 oldest users, skipping the first 5
+const page = users.query({}, {
+  orderBy: { age: 'DESC' },
+  skip: 5,
+  limit: 10,
+});
+```
+
+---
+
+### `CollectionOptions<T>`
+
+Configuration passed to `createCollection()`.
+
+```typescript
+type CollectionOptions<T> = {
+  indexes?: (keyof T)[];
+  syncers?: Syncers<T>;
+};
+```
+
+```typescript
+const users = db.createCollection<User>('users', {
+  indexes: ['email', 'age'],
+  syncers: {
+    create: async (doc) => { /* ... */ return true; },
+  },
+});
+```
+
+---
+
+### `Syncers<T>`
+
+Functions that synchronize in-memory writes with an external backend.
+
+```typescript
+type Syncers<T> = {
+  create?: (doc: Doc<T>) => Promise<boolean>;
+  update?: (doc: Doc<T>) => Promise<boolean>;
+  remove?: (docId: string) => Promise<boolean>;
+};
+```
+
+All three are optional. See the [Syncers guide](/guides/syncers/) for detailed usage.
+
+---
+
+### `CancelFn`
+
+Returned by `on()` and `listen()`. Call it to remove the listener.
+
+```typescript
+type CancelFn = () => void;
+```
+
+```typescript
+const cancel: CancelFn = users.on('create', (payload) => {
+  console.log(payload.doc.name);
+});
+
+cancel(); // Listener removed
+```
+
+---
+
+### `RemoveResult`
+
+Returned by `remove()` and as array elements from `removeMany()`.
+
+```typescript
+type RemoveResult = { removedId: string; acknowledge: true };
+```
+
+```typescript
+const result: RemoveResult = await users.remove('some-id');
+console.log(result.removedId, result.acknowledge); // "some-id" true
+```
+
+---
+
+### `EventType`
+
+Union of all supported event names.
+
+```typescript
+type EventType = 'create' | 'update' | 'remove' | 'populate' | 'syncError';
+```
+
+---
+
+### `CreatePayload<T>`
+
+Payload for the `create` event.
+
+```typescript
+type CreatePayload<T> = { doc: Doc<T> };
+```
+
+---
+
+### `UpdatePayload<T>`
+
+Payload for the `update` event. Contains the document state before and after the update, plus the patch that was applied.
+
+```typescript
+type UpdatePayload<T> = {
+  before: Doc<T>;
+  after: Doc<T>;
+  patch: Partial<T>;
+};
+```
+
+---
+
+### `RemovePayload<T>`
+
+Payload for the `remove` event.
+
+```typescript
+type RemovePayload<T> = { doc: Doc<T> };
+```
+
+---
+
+### `PopulatePayload`
+
+Payload for the `populate` event.
+
+```typescript
+type PopulatePayload = { count: number };
+```
+
+---
+
+### `SyncErrorPayload`
+
+Payload for the `syncError` event.
+
+```typescript
+type SyncErrorPayload = {
+  op: 'create' | 'update' | 'remove';
+  error: unknown;
+  docId?: string;
+};
+```
+
+---
+
+### `ListenerPayload<T>`
+
+Union type for per-document listener callbacks. The payload will be one of `CreatePayload<T>`, `UpdatePayload<T>`, or `RemovePayload<T>`.
+
+```typescript
+type ListenerPayload<T> = CreatePayload<T> | UpdatePayload<T> | RemovePayload<T>;
+```
+
+```typescript
+users.listen(doc._id, (payload: ListenerPayload<User>) => {
+  if ('before' in payload) {
+    // UpdatePayload
+  } else {
+    // CreatePayload or RemovePayload
+  }
+});
+```
+
+---
+
+### `Collection<T>`
+
+The full interface of a collection instance. Returned by `createCollection()` and `getCollection()`.
+
+```typescript
+type Collection<T> = {
+  read: (id: string) => Doc<T> | null;
+  query: (where: Where<T>, options?: QueryOptions) => Doc<T>[];
+  findOne: (where: Where<T>) => Doc<T> | null;
+  create: (doc: T) => Promise<Doc<T>>;
+  update: (id: string, patch: Partial<T>) => Promise<Doc<T>>;
+  remove: (id: string) => Promise<RemoveResult>;
+  populate: (docs: Doc<T>[]) => void;
+  listen: (id: string, handler: (payload: ListenerPayload<T>) => void) => CancelFn;
+  on: (event: EventType, handler: (payload: any) => void) => CancelFn;
+  count: (where?: Where<T>) => number;
+  exists: (id: string) => boolean;
+  clear: () => void;
+  updateMany: (where: Where<T>, patch: Partial<T>) => Promise<Doc<T>[]>;
+  removeMany: (where: Where<T>) => Promise<RemoveResult[]>;
+};
+```
+
+---
+
+### `GraphDBType`
+
+The top-level database instance returned by `GraphDB()`.
+
+```typescript
+type GraphDBType = {
+  createCollection: <T>(name: string, options?: CollectionOptions<T>) => Collection<T>;
+  getCollection: <T>(name: string) => Collection<T> | undefined;
+  listCollections: () => string[];
+  removeCollection: (name: string) => boolean;
+};
+```
+
+```typescript
+const db: GraphDBType = GraphDB();
+
+db.createCollection<User>('users');
+db.listCollections();    // ['users']
+db.getCollection('users'); // Collection<User>
+db.removeCollection('users'); // true
+```
+
+## Import structure
+
+Types are defined in `@graphdb/types` and re-exported from `@graphdb/core`:
+
+```
+@graphdb/types   <-- type definitions only, no runtime code
+    ^
+    |
+@graphdb/core    <-- re-exports all types via `export type * from '@graphdb/types'`
+```
+
+You should always import from `@graphdb/core` unless you specifically need only the type package as a dependency:
+
+```typescript
+// Recommended
+import { GraphDB, type Doc, type Where } from '@graphdb/core';
+
+// Also valid, for type-only packages
+import type { Doc, Where } from '@graphdb/types';
+```

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,0 +1,39 @@
+---
+title: GraphDB
+description: An in-memory database with sync capabilities. Zero runtime deps. TypeScript-first.
+template: splash
+hero:
+  tagline: An in-memory database with sync capabilities. Zero runtime deps. TypeScript-first.
+  actions:
+    - text: Get Started
+      link: /getting-started/installation/
+      icon: right-arrow
+      variant: primary
+    - text: View on GitHub
+      link: https://github.com/alexvcasillas/graphdb
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid stagger>
+  <Card title="Zero Dependencies" icon="rocket">
+    No runtime dependencies. Uses built-in `crypto.randomUUID()` and `Date.now()`. Lightweight and fast.
+  </Card>
+  <Card title="TypeScript-First" icon="seti:typescript">
+    Full type safety with generics. `Doc<T>`, `Where<T>`, typed event payloads, and IDE autocompletion out of the box.
+  </Card>
+  <Card title="Query Engine" icon="magnifier">
+    Powerful where clauses with operators: `eq`, `gt`, `lt`, `includes`, `startsWith`, `match`, `in`, and more. RegExp support at top level.
+  </Card>
+  <Card title="Hash Indexes" icon="list-format">
+    Optional hash indexes for O(1) equality lookups. Accelerates `eq`, primitive equality, and `in` operators automatically.
+  </Card>
+  <Card title="Real-Time Listeners" icon="star">
+    Collection-level events (`create`, `update`, `remove`, `populate`, `syncError`) and per-document listeners with O(1) unsubscribe.
+  </Card>
+  <Card title="Backend Sync" icon="cloud">
+    Optimistic writes with automatic revert on sync failure. Plug in your own create/update/remove sync functions.
+  </Card>
+</CardGrid>

--- a/apps/docs/src/index.ts
+++ b/apps/docs/src/index.ts
@@ -1,3 +1,0 @@
-// Placeholder: docs app will be built with Astro or similar.
-// For now this just re-exports types for IDE reference.
-export type { Doc, Collection, GraphDBType } from '@graphdb/types';

--- a/apps/docs/src/pages/llms-full.txt.ts
+++ b/apps/docs/src/pages/llms-full.txt.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 
 // Sidebar order for structured output
 const sectionOrder = [
@@ -30,9 +30,9 @@ const sectionOrder = [
 ];
 
 export const GET: APIRoute = async () => {
-  const docs = await getCollection('docs');
+  const docs: CollectionEntry<'docs'>[] = await getCollection('docs');
 
-  const docMap = new Map(docs.map((doc) => [doc.id, doc]));
+  const docMap = new Map(docs.map((doc: CollectionEntry<'docs'>) => [doc.id, doc]));
 
   const parts: string[] = [
     '# GraphDB — Full Documentation',
@@ -50,7 +50,7 @@ export const GET: APIRoute = async () => {
     const doc = docMap.get(slug);
     if (!doc) continue;
 
-    const title = doc.data.title;
+    const title = (doc.data as { title: string }).title;
     parts.push(`# ${title}`);
     parts.push('');
     parts.push(doc.body ?? '');
@@ -62,7 +62,7 @@ export const GET: APIRoute = async () => {
   // Append any docs not in the explicit order
   for (const doc of docs) {
     if (!sectionOrder.includes(doc.id)) {
-      parts.push(`# ${doc.data.title}`);
+      parts.push(`# ${(doc.data as { title: string }).title}`);
       parts.push('');
       parts.push(doc.body ?? '');
       parts.push('');

--- a/apps/docs/src/pages/llms-full.txt.ts
+++ b/apps/docs/src/pages/llms-full.txt.ts
@@ -1,0 +1,79 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+// Sidebar order for structured output
+const sectionOrder = [
+  'index',
+  'getting-started/installation',
+  'getting-started/quick-start',
+  'getting-started/migration-v2',
+  'guides/crud-operations',
+  'guides/querying',
+  'guides/indexes',
+  'guides/sorting-pagination',
+  'guides/listeners-events',
+  'guides/syncers',
+  'guides/bulk-operations',
+  'guides/typescript-types',
+  'api-reference/graphdb',
+  'api-reference/collection',
+  'api-reference/where-clauses',
+  'api-reference/types',
+  'advanced/architecture',
+  'advanced/performance',
+  'advanced/error-handling',
+  'advanced/patterns',
+  'examples/basic-usage',
+  'examples/real-time-ui',
+  'examples/backend-sync',
+  'examples/testing',
+];
+
+export const GET: APIRoute = async () => {
+  const docs = await getCollection('docs');
+
+  const docMap = new Map(docs.map((doc) => [doc.id, doc]));
+
+  const parts: string[] = [
+    '# GraphDB — Full Documentation',
+    '',
+    '> An in-memory database with sync capabilities. Zero runtime deps. TypeScript-first.',
+    '',
+    'Source: https://github.com/alexvcasillas/graphdb',
+    'Docs: https://graphdb.pages.dev',
+    '',
+    '---',
+    '',
+  ];
+
+  for (const slug of sectionOrder) {
+    const doc = docMap.get(slug);
+    if (!doc) continue;
+
+    const title = doc.data.title;
+    parts.push(`# ${title}`);
+    parts.push('');
+    parts.push(doc.body ?? '');
+    parts.push('');
+    parts.push('---');
+    parts.push('');
+  }
+
+  // Append any docs not in the explicit order
+  for (const doc of docs) {
+    if (!sectionOrder.includes(doc.id)) {
+      parts.push(`# ${doc.data.title}`);
+      parts.push('');
+      parts.push(doc.body ?? '');
+      parts.push('');
+      parts.push('---');
+      parts.push('');
+    }
+  }
+
+  return new Response(parts.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": ["src/**/*", "astro.config.mjs"],
+  "exclude": ["dist", ".astro"]
+}

--- a/apps/docs/wrangler.jsonc
+++ b/apps/docs/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "graphdb",
+  "compatibility_date": "2026-02-16",
+  "assets": {
+    "directory": "./dist"
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,14 @@
     "apps/docs": {
       "name": "@graphdb/docs",
       "version": "0.0.0",
+      "dependencies": {
+        "@astrojs/starlight": "^0.32.0",
+        "astro": "^5.3.0",
+        "sharp": "^0.33.0",
+      },
+      "devDependencies": {
+        "@astrojs/check": "^0.9.0",
+      },
     },
     "packages/core": {
       "name": "@graphdb/core",
@@ -27,7 +35,39 @@
     },
   },
   "packages": {
+    "@astrojs/check": ["@astrojs/check@0.9.6", "", { "dependencies": { "@astrojs/language-server": "^2.16.1", "chokidar": "^4.0.1", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA=="],
+
+    "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.7.5", "", {}, "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA=="],
+
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.3", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/yaml2ts": "^0.2.2", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.27", "@volar/language-core": "~2.4.27", "@volar/language-server": "~2.4.27", "@volar/language-service": "~2.4.27", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.15", "volar-service-css": "0.0.68", "volar-service-emmet": "0.0.68", "volar-service-html": "0.0.68", "volar-service-prettier": "0.0.68", "volar-service-typescript": "0.0.68", "volar-service-typescript-twoslash-queries": "0.0.68", "volar-service-yaml": "0.0.68", "vscode-html-languageservice": "^5.6.1", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-yO5K7RYCMXUfeDlnU6UnmtnoXzpuQc0yhlaCNZ67k1C/MiwwwvMZz+LGa+H35c49w5QBfvtr4w4Zcf5PcH8uYA=="],
+
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@6.3.10", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.5", "@astrojs/prism": "3.3.0", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "shiki": "^3.19.0", "smol-toml": "^1.5.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A=="],
+
+    "@astrojs/mdx": ["@astrojs/mdx@4.3.13", "", { "dependencies": { "@astrojs/markdown-remark": "6.3.10", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.15.0", "es-module-lexer": "^1.7.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^5.0.0" } }, "sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q=="],
+
+    "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.0", "", { "dependencies": { "sitemap": "^8.0.2", "stream-replace-string": "^2.0.0", "zod": "^3.25.76" } }, "sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA=="],
+
+    "@astrojs/starlight": ["@astrojs/starlight@0.32.6", "", { "dependencies": { "@astrojs/mdx": "^4.0.5", "@astrojs/sitemap": "^3.2.1", "@pagefind/default-ui": "^1.3.0", "@types/hast": "^3.0.4", "@types/js-yaml": "^4.0.9", "@types/mdast": "^4.0.4", "astro-expressive-code": "^0.40.0", "bcp-47": "^2.1.0", "hast-util-from-html": "^2.0.1", "hast-util-select": "^6.0.2", "hast-util-to-string": "^3.0.0", "hastscript": "^9.0.0", "i18next": "^23.11.5", "js-yaml": "^4.1.0", "klona": "^2.0.6", "mdast-util-directive": "^3.0.0", "mdast-util-to-markdown": "^2.1.0", "mdast-util-to-string": "^4.0.0", "pagefind": "^1.3.0", "rehype": "^13.0.1", "rehype-format": "^5.0.0", "remark-directive": "^3.0.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "vfile": "^6.0.2" }, "peerDependencies": { "astro": "^5.1.5" } }, "sha512-ASWGwNzq+0TmJ+GJFFxFFxx6Yra7BqIIMQbvOy/cweTHjqejB6mcaEWtS3Mag12LM7tXCES7v/fzmdPgjz8Yxw=="],
+
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
+
+    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.2", "", { "dependencies": { "yaml": "^2.5.0" } }, "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.14", "", { "dependencies": { "@changesets/config": "^3.1.2", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA=="],
 
@@ -63,17 +103,149 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
+    "@ctrl/tinycolor": ["@ctrl/tinycolor@4.2.0", "", {}, "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A=="],
+
+    "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
+
+    "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
+
+    "@emmetio/css-parser": ["@emmetio/css-parser@0.4.1", "", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ=="],
+
+    "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
+
+    "@emmetio/scanner": ["@emmetio/scanner@1.0.4", "", {}, "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="],
+
+    "@emmetio/stream-reader": ["@emmetio/stream-reader@2.2.0", "", {}, "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="],
+
+    "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@expressive-code/core": ["@expressive-code/core@0.40.2", "", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-gXY3v7jbgz6nWKvRpoDxK4AHUPkZRuJsM79vHX/5uhV9/qX6Qnctp/U/dMHog/LCVXcuOps+5nRmf1uxQVPb3w=="],
+
+    "@expressive-code/plugin-frames": ["@expressive-code/plugin-frames@0.40.2", "", { "dependencies": { "@expressive-code/core": "^0.40.2" } }, "sha512-aLw5IlDlZWb10Jo/TTDCVsmJhKfZ7FJI83Zo9VDrV0OBlmHAg7klZqw68VDz7FlftIBVAmMby53/MNXPnMjTSQ=="],
+
+    "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.40.2", "", { "dependencies": { "@expressive-code/core": "^0.40.2", "shiki": "^1.26.1" } }, "sha512-t2HMR5BO6GdDW1c1ISBTk66xO503e/Z8ecZdNcr6E4NpUfvY+MRje+LtrcvbBqMwWBBO8RpVKcam/Uy+1GxwKQ=="],
+
+    "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.40.2", "", { "dependencies": { "@expressive-code/core": "^0.40.2" } }, "sha512-/XoLjD67K9nfM4TgDlXAExzMJp6ewFKxNpfUw4F7q5Ecy+IU3/9zQQG/O70Zy+RxYTwKGw2MA9kd7yelsxnSmw=="],
+
     "@graphdb/core": ["@graphdb/core@workspace:packages/core"],
 
     "@graphdb/docs": ["@graphdb/docs@workspace:apps/docs"],
 
     "@graphdb/types": ["@graphdb/types@workspace:packages/types"],
 
+    "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -81,49 +253,361 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ=="],
+
+    "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A=="],
+
+    "@pagefind/default-ui": ["@pagefind/default-ui@1.4.0", "", {}, "sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ=="],
+
+    "@pagefind/freebsd-x64": ["@pagefind/freebsd-x64@1.4.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q=="],
+
+    "@pagefind/linux-arm64": ["@pagefind/linux-arm64@1.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw=="],
+
+    "@pagefind/linux-x64": ["@pagefind/linux-x64@1.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg=="],
+
+    "@pagefind/windows-x64": ["@pagefind/windows-x64@1.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.57.1", "", { "os": "android", "cpu": "arm64" }, "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.57.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.57.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.57.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.57.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.57.1", "", { "os": "linux", "cpu": "arm" }, "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.57.1", "", { "os": "linux", "cpu": "arm" }, "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.57.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.57.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.57.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.57.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.57.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.57.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.57.1", "", { "os": "linux", "cpu": "x64" }, "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.57.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.57.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.57.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.57.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
+
+    "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+
+    "@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
     "@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
+
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
+
+    "@volar/language-server": ["@volar/language-server@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "path-browserify": "^1.0.1", "request-light": "^0.7.0", "vscode-languageserver": "^9.0.1", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw=="],
+
+    "@volar/language-service": ["@volar/language-service@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
+    "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
+
+    "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
+
+    "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "astro": ["astro@5.17.2", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.5", "@astrojs/markdown-remark": "6.3.10", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.0", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA=="],
+
+    "astro-expressive-code": ["astro-expressive-code@0.40.2", "", { "dependencies": { "rehype-expressive-code": "^0.40.2" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0" } }, "sha512-yJMQId0yXSAbW9I6yqvJ3FcjKzJ8zRL7elbJbllkv1ZJPlsI0NI83Pxn1YL1IapEM347EvOOkSW2GL+2+NO61w=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "base-64": ["base-64@1.0.0", "", {}, "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="],
+
+    "bcp-47": ["bcp-47@2.1.0", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w=="],
+
+    "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
+    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
+
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-selector-parser": ["css-selector-parser@3.3.0", "", {}, "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g=="],
+
+    "css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "deterministic-object-hash": ["deterministic-object-hash@2.0.2", "", { "dependencies": { "base-64": "^1.0.0" } }, "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ=="],
+
+    "devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
+
+    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
+
+    "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
+
+    "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
+
+    "estree-util-build-jsx": ["estree-util-build-jsx@3.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-walker": "^3.0.0" } }, "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ=="],
+
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "estree-util-scope": ["estree-util-scope@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0" } }, "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ=="],
+
+    "estree-util-to-js": ["estree-util-to-js@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "astring": "^1.8.0", "source-map": "^0.7.0" } }, "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg=="],
+
+    "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "expressive-code": ["expressive-code@0.40.2", "", { "dependencies": { "@expressive-code/core": "^0.40.2", "@expressive-code/plugin-frames": "^0.40.2", "@expressive-code/plugin-shiki": "^0.40.2", "@expressive-code/plugin-text-markers": "^0.40.2" } }, "sha512-1zIda2rB0qiDZACawzw2rbdBQiWHBT56uBctS+ezFe5XMAaFaHLnnSYND/Kd+dVzO9HfCXRDpzH3d+3fvOWRcw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
+
+    "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
+
+    "fontkitten": ["fontkitten@1.0.2", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q=="],
+
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -131,37 +615,275 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
+
+    "hast-util-embedded": ["hast-util-embedded@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-is-element": "^3.0.0" } }, "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA=="],
+
+    "hast-util-format": ["hast-util-format@1.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-embedded": "^3.0.0", "hast-util-minify-whitespace": "^1.0.0", "hast-util-phrasing": "^3.0.0", "hast-util-whitespace": "^3.0.0", "html-whitespace-sensitive-tag-names": "^3.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA=="],
+
+    "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
+
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-has-property": ["hast-util-has-property@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA=="],
+
+    "hast-util-is-body-ok-link": ["hast-util-is-body-ok-link@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ=="],
+
+    "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
+
+    "hast-util-minify-whitespace": ["hast-util-minify-whitespace@1.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-embedded": "^3.0.0", "hast-util-is-element": "^3.0.0", "hast-util-whitespace": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-phrasing": ["hast-util-phrasing@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-embedded": "^3.0.0", "hast-util-has-property": "^3.0.0", "hast-util-is-body-ok-link": "^3.0.0", "hast-util-is-element": "^3.0.0" } }, "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-select": ["hast-util-select@6.0.4", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "bcp-47-match": "^2.0.0", "comma-separated-tokens": "^2.0.0", "css-selector-parser": "^3.0.0", "devlop": "^1.0.0", "direction": "^2.0.0", "hast-util-has-property": "^3.0.0", "hast-util-to-string": "^3.0.0", "hast-util-whitespace": "^3.0.0", "nth-check": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw=="],
+
+    "hast-util-to-estree": ["hast-util-to-estree@3.1.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-attach-comments": "^3.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
+    "hast-util-to-string": ["hast-util-to-string@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A=="],
+
+    "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "html-whitespace-sensitive-tag-names": ["html-whitespace-sensitive-tag-names@3.0.1", "", {}, "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
+
+    "i18next": ["i18next@23.16.8", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
+
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
+
+    "mdast-util-directive": ["mdast-util-directive@3.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx": ["mdast-util-mdx@3.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-directive": ["micromark-extension-directive@3.0.2", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-extension-mdx-expression": ["micromark-extension-mdx-expression@3.0.1", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q=="],
+
+    "micromark-extension-mdx-jsx": ["micromark-extension-mdx-jsx@3.0.2", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ=="],
+
+    "micromark-extension-mdx-md": ["micromark-extension-mdx-md@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ=="],
+
+    "micromark-extension-mdxjs": ["micromark-extension-mdxjs@3.0.0", "", { "dependencies": { "acorn": "^8.0.0", "acorn-jsx": "^5.0.0", "micromark-extension-mdx-expression": "^3.0.0", "micromark-extension-mdx-jsx": "^3.0.0", "micromark-extension-mdx-md": "^2.0.0", "micromark-extension-mdxjs-esm": "^3.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ=="],
+
+    "micromark-extension-mdxjs-esm": ["micromark-extension-mdxjs-esm@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-mdx-expression": ["micromark-factory-mdx-expression@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-events-to-acorn": ["micromark-util-events-to-acorn@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+
+    "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
+
+    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
@@ -173,9 +895,23 @@
 
     "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
+    "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
+
+    "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
+
+    "pagefind": ["pagefind@1.4.0", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.4.0", "@pagefind/darwin-x64": "1.4.0", "@pagefind/freebsd-x64": "1.4.0", "@pagefind/linux-arm64": "1.4.0", "@pagefind/linux-x64": "1.4.0", "@pagefind/windows-x64": "1.4.0" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g=="],
+
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -183,55 +919,299 @@
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
+    "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
+
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
+
+    "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
+
+    "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
+
+    "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
+
+    "rehype-expressive-code": ["rehype-expressive-code@0.40.2", "", { "dependencies": { "expressive-code": "^0.40.2" } }, "sha512-+kn+AMGCrGzvtH8Q5lC6Y5lnmTV/r33fdmi5QU/IH1KPHKobKr5UnLwJuqHv5jBTSN/0v2wLDS7RTM73FVzqmQ=="],
+
+    "rehype-format": ["rehype-format@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-format": "^1.0.0" } }, "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ=="],
+
+    "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
+
+    "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
+
+    "remark-directive": ["remark-directive@3.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^3.0.0", "unified": "^11.0.0" } }, "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-mdx": ["remark-mdx@3.1.1", "", { "dependencies": { "mdast-util-mdx": "^3.0.0", "micromark-extension-mdxjs": "^3.0.0" } }, "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-smartypants": ["remark-smartypants@3.0.2", "", { "dependencies": { "retext": "^9.0.0", "retext-smartypants": "^6.0.0", "unified": "^11.0.4", "unist-util-visit": "^5.0.0" } }, "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
+
+    "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
+
+    "retext-smartypants": ["retext-smartypants@6.2.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ=="],
+
+    "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "sax": ["sax@1.4.4", "", {}, "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "sitemap": ["sitemap@8.0.2", "", { "dependencies": { "@types/node": "^17.0.5", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/cli.js" } }, "sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ=="],
+
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "svgo": ["svgo@4.0.0", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.4.1" }, "bin": "./bin/svgo.js" }, "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw=="],
+
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
+    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unifont": ["unifont@0.7.4", "", { "dependencies": { "css-tree": "^3.1.0", "ofetch": "^1.5.1", "ohash": "^2.0.11" } }, "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg=="],
+
+    "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-modify-children": ["unist-util-modify-children@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "array-iterate": "^2.0.0" } }, "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-position-from-estree": ["unist-util-position-from-estree@2.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ=="],
+
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-children": ["unist-util-visit-children@3.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "unstorage": ["unstorage@1.17.4", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.5", "lru-cache": "^11.2.0", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
+
+    "volar-service-css": ["volar-service-css@0.0.68", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q=="],
+
+    "volar-service-emmet": ["volar-service-emmet@0.0.68", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ=="],
+
+    "volar-service-html": ["volar-service-html@0.0.68", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-fru9gsLJxy33xAltXOh4TEdi312HP80hpuKhpYQD4O5hDnkNPEBdcQkpB+gcX0oK0VxRv1UOzcGQEUzWCVHLfA=="],
+
+    "volar-service-prettier": ["volar-service-prettier@0.0.68", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-grUmWHkHlebMOd6V8vXs2eNQUw/bJGJMjekh/EPf/p2ZNTK0Uyz7hoBRngcvGfJHMsSXZH8w/dZTForIW/4ihw=="],
+
+    "volar-service-typescript": ["volar-service-typescript@0.0.68", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-z7B/7CnJ0+TWWFp/gh2r5/QwMObHNDiQiv4C9pTBNI2Wxuwymd4bjEORzrJ/hJ5Yd5+OzeYK+nFCKevoGEEeKw=="],
+
+    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.68", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-NugzXcM0iwuZFLCJg47vI93su5YhTIweQuLmZxvz5ZPTaman16JCvmDZexx2rd5T/75SNuvvZmrTOTNYUsfe5w=="],
+
+    "volar-service-yaml": ["volar-service-yaml@0.0.68", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.19.2" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-84XgE02LV0OvTcwfqhcSwVg4of3MLNUWPMArO6Aj8YXqyEVnPu8xTEMY2btKSq37mVAPuaEVASI4e3ptObmqcA=="],
+
+    "vscode-css-languageservice": ["vscode-css-languageservice@6.3.9", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-1tLWfp+TDM5ZuVWht3jmaY5y7O6aZmpeXLoHl5bv1QtRsRKt4xYGRMmdJa5Pqx/FTkgRbsna9R+Gn2xE+evVuA=="],
+
+    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.1", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-5Mrqy5CLfFZUgkyhNZLA1Ye5g12Cb/v6VM7SxUzZUaRKWMDz4md+y26PrfRTSU0/eQAl3XpO9m2og+GGtDMuaA=="],
+
+    "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
+    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
+
+    "yaml-language-server": ["yaml-language-server@1.19.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "lodash": "4.17.21", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-9F3myNmJzUN/679jycdMxqtydPSDRAarSj3wPiF7pchEPnO9Dg07Oc+gIYLqXR4L+g+FSEVXXv2+mr54StLFOg=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "yocto-spinner": ["yocto-spinner@0.2.3", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@astrojs/telemetry/ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "@expressive-code/plugin-shiki/shiki": ["shiki@1.29.2", "", { "dependencies": { "@shikijs/core": "1.29.2", "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/langs": "1.29.2", "@shikijs/themes": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
@@ -239,8 +1219,184 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@types/sax/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "astro/ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "astro/p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
+
+    "astro/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "astro/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
+    "sitemap/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "yaml-language-server/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/core": ["@shikijs/core@1.29.2", "", { "dependencies": { "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "oniguruma-to-es": "^2.2.0" } }, "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1" } }, "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/langs": ["@shikijs/langs@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2" } }, "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/themes": ["@shikijs/themes@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2" } }, "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@1.29.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw=="],
+
+    "astro/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "astro/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "astro/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "astro/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "astro/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "astro/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "astro/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "astro/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "astro/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "astro/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "astro/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "astro/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "astro/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "astro/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "astro/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "astro/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "astro/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "astro/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "astro/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-javascript/oniguruma-to-es": ["oniguruma-to-es@2.3.0", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^5.1.1", "regex-recursion": "^5.1.1" } }, "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g=="],
+
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-javascript/oniguruma-to-es/regex": ["regex@5.1.1", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw=="],
+
+    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-javascript/oniguruma-to-es/regex-recursion": ["regex-recursion@5.1.1", "", { "dependencies": { "regex": "^5.1.1", "regex-utilities": "^2.3.0" } }, "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test": "bun --filter '*' test",
     "build": "bun run --filter @graphdb/types build && bun run --filter @graphdb/core build && bun run --filter @graphdb/docs build",
     "clean": "bun --filter '*' clean",
+    "docs:dev": "bun run --filter @graphdb/docs dev",
+    "docs:build": "bun run --filter @graphdb/docs build",
+    "docs:preview": "bun run --filter @graphdb/docs preview",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish"


### PR DESCRIPTION
This pull request sets up the documentation site for GraphDB using Astro and the Starlight integration. It introduces a full documentation configuration, content structure, and supporting files for deployment and developer experience. The most important changes are grouped below:

**Documentation Site Setup**

* Added `astro.config.mjs` to configure the docs site with Starlight, including site metadata, sidebar navigation, and social/edit links.
* Introduced content collection schema with `src/content.config.ts` for type-safe documentation pages.
* Added a detailed architecture document at `src/content/docs/advanced/architecture.md` explaining GraphDB's internal design, including storage, indexing, query planning, listeners, and syncers.

**Developer and Build Tooling**

* Updated `package.json` to include Astro, Starlight, and related dependencies, and replaced placeholder scripts with actual build, dev, clean, and typecheck commands.
* Added `.gitignore` rules for build and cache directories (`dist/`, `.astro/`).

**Public Assets and SEO**

* Added `public/llms.txt` with a concise GraphDB overview, install instructions, and key concepts for LLM consumption or quick reference.
* Added `public/robots.txt` to allow all web crawlers and specify the sitemap location for search engines.